### PR TITLE
モバイルで添削できるレスポンシブ対応

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ Optional/legacy: `SUPABASE_SERVICE_ROLE_KEY` may appear in `conf/.env` (commente
 - Backend: Python 3.12 (Vercel Python runtime), deps in `backend/requirements.txt` and root `requirements.txt` (FastAPI, uvicorn, asyncpg, pytest, python-dotenv). Runs via `uvicorn app.main:app` locally, listens on `${PORT:-8000}`, has a `/health` endpoint. On Vercel, served as a serverless function at `/api/*`.
 - Frontend: Next.js 15 / React 19. No Dockerfile — frontend is deployed via Vercel (see Deployment section).
 - **Build-time vs runtime**: all `NEXT_PUBLIC_*` vars are baked into the frontend at `npm run build` time. On Vercel, configure these in Project Settings → Environment Variables. Locally, set them in `conf/.env` before running `npm run build`.
-- `frontend/next.config.js` uses Vercel's native Next.js build (no explicit `output` mode). The former `output: 'export'` and `frontend/Dockerfile` have been removed.
+- `frontend/next.config.js` still sets `output: 'export'` (plus `trailingSlash: true`, `images.unoptimized`), so `npm run build` produces a static export in `frontend/out/`. An earlier revision of this file claimed the explicit output mode had been removed — it had not. `frontend/Dockerfile` **is** gone. Note `frontend/out/` contains 18 tracked files from before `out/` was added to `.gitignore`; a local build overwrites them, so do not commit (or delete) that churn.
 - Backend `.env` file discovery order (`backend/app/main.py`): `${APP_ROOT}/../conf/.env`, then `${APP_ROOT}/.env`, then `/conf/.env`. `APP_ROOT` defaults to `/app` (container path).
 - **Vercel entrypoint**: `api/index.py` at repo root imports `app` from `backend.app.main` for Vercel's Python runtime detection.
 

--- a/docs/SYSTEM-DESIGN.md
+++ b/docs/SYSTEM-DESIGN.md
@@ -206,6 +206,8 @@ AI suggestions are generated via `POST /suggestions` (Gemini → Groq → Cloudf
 
 The frontend is a static-exported Next.js app that: (1) gates the workspace on Supabase session, (2) talks only to the FastAPI JSON API, (3) never opens the database directly. Visual layout and component styling are implementation details of `page.tsx` / `components/ui/`; they are out of scope for this engineering design doc except insofar as they define the client of the APIs above.
 
+**Viewport-dependent presentation carries no state of its own.** Below the `lg` breakpoint the workspace shows one pane at a time (editor or review) instead of both, and the section tabs and account controls move into the session drawer. All of this is presentation: which pane is showing lives in component state that is deliberately not persisted and resets with the session, no request shape changes, and no persisted or server-visible state depends on viewport size. Which breakpoint is in force is decided by CSS rather than a JavaScript viewport reading, so there is no second definition of the breakpoints to keep in sync. See `docs/UI-DESIGN.md` for the breakpoint table and `openspec/changes/responsive-mobile-correction-ui/` for the rationale.
+
 ### 5.5 Deployment and rollout (as-built)
 
 | Piece | Reality |

--- a/docs/UI-DESIGN.md
+++ b/docs/UI-DESIGN.md
@@ -485,13 +485,62 @@ CSS animation triggered when a job **completes** (transitions to `completed` / b
 
 ## Mobile Responsive Behavior
 
-At breakpoints below `lg` (1024px):
+Three breakpoints are load-bearing, each deciding one thing (OpenSpec change `responsive-mobile-correction-ui`):
 
-- TopAppBar remains visible
-- Left pane (session list) is always the floating slide-out Sheet — the docked column is `lg`+ only. The Sheet itself is **not** mobile-only any more; it is the floating presentation at every width (see "Session pane: docked ⇄ floating")
-- The Sheet's dock button is hidden below `lg`, since there is nothing to dock to
-- Center and right panes stack vertically
-- New Session button becomes icon-only
+| Breakpoint | What it decides |
+|---|---|
+| `sm` (640px) | Below it, identity and sign-out move from the TopAppBar to the foot of the session drawer, and the New Session button becomes icon-only |
+| `md` (768px) | Below it, the section tabs (`Sessions` / `Dashboard` / `Archive`) move from the TopAppBar into the session drawer |
+| `lg` (1024px) | Below it, one workspace pane is on screen at a time (see below) and the session list is always the floating Sheet — the docked column is `lg`+ only |
+
+The TopAppBar is visible at every width. At 320px it holds the menu trigger, the wordmark and the three controls a correction session needs at hand: new session, notifications, settings.
+
+### One pane at a time below `lg`
+
+Above `lg` the editor and review panes sit side by side. Below it they used to stack, which put two independently scrolling regions inside one fixed-height container and let a long proposal list squeeze the editor to nothing. Instead:
+
+```
+below lg                              lg and above
+┌──────────────────────┐              ┌─────────┬────────┐
+│ ☰  MJAI    + 🔔 ⚙    │              │ Editor  │ Queue  │
+├──────────┬───────────┤              │         │ + AI   │
+│  編集    │ 添削案 ③  │  ← switch    │         │        │
+├──────────┴───────────┤              │         │        │
+│ Editor  (full height)│              │         │        │
+└──────────────────────┘              └─────────┴────────┘
+```
+
+- Which pane shows is `mobilePane` state, deliberately **not** persisted: a stored pane would reopen the app on the review side of a session the user has since left. It resets when the session changes
+- Whether the switch is in force is left entirely to CSS (`lg:` classes show and hide the panes), so there is no second definition of `lg` in JS to drift from Tailwind's
+- The 添削案 button carries a count of what is waiting in the pane that is off screen: proposals under review, or failing that the generations that will produce them
+- Opening a completed job for review brings the review pane forward — the same effect that scrolls the suggestions card into view on desktop
+
+### Viewport height
+
+The shell uses `.h-viewport` / `.min-h-viewport` from `globals.css`, each a `100vh` declaration followed by `100dvh`, rather than `h-screen` or `h-dvh`:
+
+- `dvh` tracks the viewport the browser is actually showing, shrinking for mobile address bars where `vh` reports the largest possible viewport and leaves the bottom of the app behind browser chrome
+- The `vh` line is a real fallback, not decoration: the panes take their height from the shell, so a browser that dropped an unknown unit would collapse the workspace rather than degrade it
+- A declaration pair rather than two utilities, because which of `h-screen` / `h-dvh` wins depends on ordering in the generated sheet
+- `layout.tsx` sets `interactiveWidget: 'resizes-content'` so the layout viewport — and therefore `dvh` — also shrinks for the on-screen keyboard
+- `maximumScale` / `userScalable` are deliberately absent. Suppressing pinch zoom is the routine collateral damage of a mobile pass, and this app shows dense CJK text people need to magnify
+
+Prefer flex-derived heights over `calc(100vh - …)`, which encodes a guess about how much chrome sits above an element and drifts when the header changes. For `fixed` elements a percentage (`max-h-[90%]`) resolves against the initial containing block, which is the visible viewport — that is what bounds the prompt dialog.
+
+### Pointer capability, not screen size
+
+Affordances that depend on hovering are gated on whether the pointer can hover, not on width — a narrow desktop window can hover, a 1280px tablet cannot:
+
+| Mechanism | Where | Meaning |
+|---|---|---|
+| `can-hover:` variant (`tailwind.config.js`) | `can-hover:opacity-0 can-hover:group-hover:opacity-100` | `@media (hover: hover) and (pointer: fine)`. Quiet-until-hover reveals apply only where hovering is possible; elsewhere the control is simply present |
+| `.touch-target` class (`globals.css`) | Icon-only buttons | Under `@media (hover: none)`, a 44px minimum with flex centering. A 18px glyph in `p-1` is a 26px target, and a minimum size alone would strand the glyph in a corner |
+
+Both add rules inside a media query and never alter the base class, so desktop density is untouched. Where a hover-revealed control was the only route to an action — selecting a proposal, previously double-click only — the visible control is also a single-activation route.
+
+### Rows that cannot fit a narrow viewport
+
+Rows whose contents need more than 320px get `flex-wrap`, with what yields chosen per row rather than uniformly. The session name keeps a `basis-48` it will fight for so the short timing readouts wrap instead of the name being cut to a few characters; the exemplar card heading truncates for the mirror-image reason, being fixed text the user can predict next to badges that describe their own input.
 
 ---
 
@@ -499,9 +548,9 @@ At breakpoints below `lg` (1024px):
 
 | File | Purpose |
 |---|---|
-| `frontend/src/app/globals.css` | CSS custom properties (design tokens) |
-| `frontend/tailwind.config.js` | Tailwind theme extensions |
-| `frontend/src/app/layout.tsx` | Font loading (Inter, Material Symbols) |
+| `frontend/src/app/globals.css` | CSS custom properties (design tokens), `.h-viewport` / `.min-h-viewport`, `.touch-target` |
+| `frontend/tailwind.config.js` | Tailwind theme extensions, `can-hover` variant |
+| `frontend/src/app/layout.tsx` | Font loading (Inter, Material Symbols), `viewport` export (keyboard-aware layout, zoom left enabled) |
 | `frontend/components.json` | shadcn/ui component library config |
 
 When updating design tokens, modify these source files first, then update this document to match.

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   transform: {
     "^.+\\.(ts|tsx)$": ["babel-jest", { configFile: "./babel.config.jest.js" }],
   },
-  setupFilesAfterEnv: ["@testing-library/jest-dom"],
+  setupFilesAfterEnv: ["@testing-library/jest-dom", "<rootDir>/jest.setup.js"],
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
     "\\.(css|less|scss|sass)$": "identity-obj-proxy"

--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -1,0 +1,8 @@
+// jsdom has no layout engine, so it omits the scrolling APIs entirely rather
+// than making them no-ops. Any component that scrolls something into view
+// therefore throws under test — and because the call is deferred by a timer,
+// whether it throws depends on how long the test happens to run, which made it
+// a flake that only surfaced on slower CI machines.
+if (typeof Element !== "undefined" && !Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = function scrollIntoView() {}
+}

--- a/frontend/src/app/__tests__/mobilePaneSwitch.test.tsx
+++ b/frontend/src/app/__tests__/mobilePaneSwitch.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * The editor/review pane switch that below `lg` decides which of the two panes
+ * is on screen.
+ *
+ * Which breakpoint is in force is a CSS question, and jsdom applies no
+ * stylesheet, so these tests cover the part that is not CSS: the switch's own
+ * state, and the fact that work arriving for review moves the switch — without
+ * which a phone user would confirm a completed job and be left looking at the
+ * editor, with the proposals in the pane they cannot see.
+ */
+import React from "react"
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import fetchMock from "jest-fetch-mock"
+
+import TextCorrectionApp from "../page"
+import { AuthProvider } from "../auth-provider"
+import { Toaster } from "@/components/ui/toaster"
+
+fetchMock.enableMocks()
+
+jest.mock("@/lib/supabaseClient", () => {
+  const fakeSession = {
+    access_token: "test-access-token",
+    user: { email: "owner@example.com" },
+  }
+  return {
+    supabase: {
+      auth: {
+        getSession: jest.fn().mockResolvedValue({ data: { session: fakeSession } }),
+        onAuthStateChange: jest.fn().mockReturnValue({
+          data: { subscription: { unsubscribe: jest.fn() } },
+        }),
+        signInWithOAuth: jest.fn(),
+        signOut: jest.fn(),
+      },
+    },
+  }
+})
+
+jest.mock("@/lib/webllm/webgpu", () => ({
+  checkWebGPUSupport: jest.fn().mockReturnValue({ supported: false, reason: "WebGPU非対応" }),
+}))
+jest.mock("@/lib/webllm/engineReady", () => ({
+  isEngineReady: jest.fn().mockReturnValue(false),
+}))
+jest.mock("@/lib/webllm/config", () => ({
+  WEBLLM_MODEL_DISPLAY_NAME: "test-model",
+  WEBLLM_MODEL_ID: "test-model-id",
+}))
+jest.mock("@/lib/webllm/diagnostics", () => ({
+  formatElapsedTime: (ms: number) => `${ms}ms`,
+  formatDownloadProgress: () => "0%",
+  PHASE_LABELS: {},
+  getDiagnosticsTracker: () => ({ getState: () => ({}) }),
+}))
+jest.mock("@/lib/webllm/engine", () => ({
+  generateSuggestions: jest.fn(),
+}))
+
+function routeApi() {
+  fetchMock.mockResponse(async (req) => {
+    const path = new URL(req.url).pathname
+    if (path.endsWith("/sessions") && req.method === "GET") return JSON.stringify([])
+    if (path.endsWith("/sessions") && req.method === "POST") {
+      return JSON.stringify({
+        sessionId: "session-1",
+        name: "セッション 1",
+        createdAt: new Date().toISOString(),
+        correctionCount: 0,
+      })
+    }
+    if (path.endsWith("/histories") && req.method === "GET") return JSON.stringify([])
+    if (path.endsWith("/histories") && req.method === "POST") {
+      return JSON.stringify({ historyId: "hist-1", status: "pending" })
+    }
+    if (path.endsWith("/suggestions")) {
+      return JSON.stringify({
+        suggestions: [
+          { id: "1", original: "比較し", reason: "「比較し」では原文の対照の含意が落ちる。" },
+        ],
+        overallComment: "整体评价",
+      })
+    }
+    if (path.endsWith("/proposals")) return JSON.stringify({ proposalId: "prop-1" })
+    return JSON.stringify({})
+  })
+}
+
+function paneSwitch() {
+  return screen.getByRole("group", { name: "表示するペーン" })
+}
+
+/** Scoped to the switch, so `編集` cannot match an edit control elsewhere. */
+function paneButton(name: "編集" | "添削案") {
+  return within(paneSwitch()).getByRole("button", { name: new RegExp(`^${name}`) })
+}
+
+function renderApp() {
+  render(
+    <AuthProvider>
+      <Toaster />
+      <TextCorrectionApp />
+    </AuthProvider>,
+  )
+}
+
+async function startSession() {
+  renderApp()
+  await waitFor(() => expect(screen.getByText("新しいセッション作成")).toBeInTheDocument())
+  fireEvent.click(screen.getByText("新しいセッション作成"))
+  await waitFor(() =>
+    expect(
+      screen.getByPlaceholderText("原文テキストをここに貼り付けてください..."),
+    ).toBeInTheDocument(),
+  )
+}
+
+async function generateAndConfirm() {
+  fireEvent.change(screen.getByPlaceholderText("原文テキストをここに貼り付けてください..."), {
+    target: { value: "多伦多大学的研究者对比了三十种灵长类动物的睡眠数据" },
+  })
+  fireEvent.change(screen.getByPlaceholderText("添削対象テキストをここに貼り付けてください..."), {
+    target: { value: "トロント大学の研究者は３０種類の霊長類動物の睡眠データを比較し" },
+  })
+  fireEvent.click(screen.getByRole("button", { name: /Generate AI Suggestions/i }))
+  await waitFor(() => expect(screen.getByText("確認")).toBeInTheDocument())
+  fireEvent.click(screen.getByText("確認"))
+  await waitFor(() => expect(screen.getByText("AI Suggestions")).toBeInTheDocument())
+}
+
+beforeAll(() => {
+  Object.assign(navigator, { clipboard: { writeText: jest.fn().mockResolvedValue(undefined) } })
+})
+
+beforeEach(() => {
+  fetchMock.resetMocks()
+  localStorage.clear()
+  process.env.NEXT_PUBLIC_FRONTEND_MODE = "real"
+})
+
+test("there is nothing to switch between until a session is open", async () => {
+  routeApi()
+  renderApp()
+
+  await waitFor(() => expect(screen.getByText("セッションを開始")).toBeInTheDocument())
+  expect(screen.queryByRole("group", { name: "表示するペーン" })).not.toBeInTheDocument()
+})
+
+test("a session opens on the editor, and the switch moves between the two panes", async () => {
+  routeApi()
+  await startSession()
+
+  expect(paneSwitch()).toBeInTheDocument()
+  expect(paneButton("編集")).toHaveAttribute("aria-pressed", "true")
+  expect(paneButton("添削案")).toHaveAttribute("aria-pressed", "false")
+
+  fireEvent.click(paneButton("添削案"))
+  expect(paneButton("添削案")).toHaveAttribute("aria-pressed", "true")
+  expect(paneButton("編集")).toHaveAttribute("aria-pressed", "false")
+
+  fireEvent.click(paneButton("編集"))
+  expect(paneButton("編集")).toHaveAttribute("aria-pressed", "true")
+})
+
+test("confirming a completed job brings the review pane forward", async () => {
+  routeApi()
+  await startSession()
+  expect(paneButton("編集")).toHaveAttribute("aria-pressed", "true")
+
+  await generateAndConfirm()
+
+  expect(paneButton("添削案")).toHaveAttribute("aria-pressed", "true")
+  expect(paneButton("編集")).toHaveAttribute("aria-pressed", "false")
+  // The switch also reports what is waiting in the pane that is off screen.
+  expect(paneButton("添削案")).toHaveTextContent("1")
+})

--- a/frontend/src/app/__tests__/mobilePaneSwitch.test.tsx
+++ b/frontend/src/app/__tests__/mobilePaneSwitch.test.tsx
@@ -175,3 +175,47 @@ test("confirming a completed job brings the review pane forward", async () => {
   // The switch also reports what is waiting in the pane that is off screen.
   expect(paneButton("添削案")).toHaveTextContent("1")
 })
+
+test("a proposal can be selected with one activation, and deselected with another", async () => {
+  routeApi()
+  await startSession()
+  await generateAndConfirm()
+
+  // Double-click remains the desktop route; this is the one a thumb can take.
+  const select = screen.getByRole("button", { name: "この提案を選択" })
+  expect(select).toHaveAttribute("aria-pressed", "false")
+
+  fireEvent.click(select)
+  const deselect = screen.getByRole("button", { name: "この提案の選択を解除" })
+  expect(deselect).toHaveAttribute("aria-pressed", "true")
+  // Selection order is what the save step reads, so it has to be assigned.
+  expect(screen.getByText("選択済み: 1/3+")).toBeInTheDocument()
+
+  fireEvent.click(deselect)
+  expect(screen.getByRole("button", { name: "この提案を選択" })).toHaveAttribute(
+    "aria-pressed",
+    "false",
+  )
+  expect(screen.getByText("選択済み: 0/3+")).toBeInTheDocument()
+})
+
+test("the drawer carries the section tabs, and choosing one closes it", async () => {
+  routeApi()
+  // The session pane docks into the layout at lg and above, where the menu
+  // button collapses that column instead of opening a drawer. jsdom reports a
+  // 1024px window by default, so narrow it first to get the drawer.
+  Object.defineProperty(window, "innerWidth", { value: 375, configurable: true })
+  await startSession()
+
+  fireEvent.click(screen.getByRole("button", { name: "セッション一覧を開く" }))
+  const drawer = await screen.findByRole("dialog")
+
+  // Both copies of the tab list are in the DOM at once — which one is on screen
+  // is a CSS question — so the drawer's copy is addressed through the drawer.
+  fireEvent.click(within(drawer).getByRole("button", { name: "Archive" }))
+
+  await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument())
+  expect(
+    screen.getByText("この機能は現在開発中です。今後のアップデートをお待ちください。"),
+  ).toBeInTheDocument()
+})

--- a/frontend/src/app/__tests__/viewportConfig.test.ts
+++ b/frontend/src/app/__tests__/viewportConfig.test.ts
@@ -1,0 +1,29 @@
+/**
+ * The document's viewport declaration.
+ *
+ * Two things about it are easy to break by accident and expensive to notice: the
+ * keyboard-aware layout the workspace's `dvh` height depends on, and the absence
+ * of a zoom lock. Suppressing pinch zoom is the routine collateral damage of a
+ * mobile pass, and this app shows dense CJK text that people need to magnify.
+ */
+// `next/font/google` is a build-time transform, not a runtime module, so it has
+// to be stubbed to import the layout at all.
+jest.mock("next/font/google", () => ({
+  Inter: () => ({ variable: "--font-inter" }),
+  Geist_Mono: () => ({ variable: "--font-geist-mono" }),
+}))
+
+import { viewport } from "../layout"
+
+test("the layout viewport resizes for the on-screen keyboard", () => {
+  expect(viewport.width).toBe("device-width")
+  expect(viewport.initialScale).toBe(1)
+  // Without this only the visual viewport shrinks, so `dvh` keeps reporting the
+  // full height and the focused field can sit behind the keyboard.
+  expect(viewport.interactiveWidget).toBe("resizes-content")
+})
+
+test("zoom is not suppressed", () => {
+  expect(viewport.maximumScale).toBeUndefined()
+  expect(viewport.userScalable).toBeUndefined()
+})

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -190,6 +190,22 @@ a {
     min-height: 100dvh;
   }
 
+  /* Icon-only controls in this app are sized for a cursor (an 18px glyph in
+     `p-1` is a 26px target). Where the pointer cannot hover it is also a
+     finger, so those controls get the 44px minimum. Scoped to `hover: none` so
+     desktop density is untouched, and applied with flex centering because a
+     minimum size alone would leave the glyph in the corner of a larger box.
+     The hover-capable counterpart is the `can-hover:` variant (tailwind.config.js). */
+  @media (hover: none) {
+    .touch-target {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 2.75rem;
+      min-height: 2.75rem;
+    }
+  }
+
   /* Used by HighlightedTextarea's backdrop layer: scrollTop/scrollLeft are
      mirrored from the real textarea via JS, so no visible/interactive
      scrollbar is needed on this layer. */

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -169,6 +169,27 @@ a {
 }
 
 @layer utilities {
+  /* Shell height. `dvh` tracks the viewport the browser is actually showing —
+     it shrinks for mobile address bars and, with
+     `interactive-widget=resizes-content` (see layout.tsx), for the on-screen
+     keyboard — where `vh` reports the largest possible viewport and leaves the
+     bottom of the app behind browser chrome.
+
+     The `vh` declaration is a real fallback, not decoration: the shell is a
+     flex column whose panes take their height from it, so a browser that drops
+     an unknown `dvh` value would collapse the workspace rather than degrade it.
+     Written as a declaration pair instead of Tailwind's `h-screen h-dvh`
+     because that pair's winner depends on utility ordering in the generated
+     sheet, which is not something the shell's height should rest on. */
+  .h-viewport {
+    height: 100vh;
+    height: 100dvh;
+  }
+  .min-h-viewport {
+    min-height: 100vh;
+    min-height: 100dvh;
+  }
+
   /* Used by HighlightedTextarea's backdrop layer: scrollTop/scrollLeft are
      mirrored from the real textarea via JS, so no visible/interactive
      scrollbar is needed on this layer. */

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Inter, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "@/components/ui/toaster";
@@ -21,6 +21,21 @@ export const metadata: Metadata = {
   description: "日本語テキスト添削支援アプリケーション",
 };
 
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  // By default only the visual viewport shrinks when the on-screen keyboard
+  // opens, so `dvh` keeps reporting the full height and the field being typed
+  // into can end up behind the keyboard. `resizes-content` shrinks the layout
+  // viewport too, which is what makes `.h-viewport` follow the keyboard.
+  // Ignored where unsupported (pre-Chrome 108, Safari), leaving today's
+  // behaviour.
+  interactiveWidget: "resizes-content",
+  // `maximumScale` and `userScalable` are deliberately absent: suppressing
+  // pinch zoom is the usual collateral damage of a mobile pass and this app
+  // shows dense CJK text that people need to be able to magnify.
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -28,7 +43,7 @@ export default function RootLayout({
 }>) {
   // suppressHydrationWarning: browser extensions (e.g. UI.Vision/Kantu) inject attrs like data-kantu on <html>
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="ja" suppressHydrationWarning>
       <head>
         <link
           href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap"

--- a/frontend/src/app/login-screen.tsx
+++ b/frontend/src/app/login-screen.tsx
@@ -44,7 +44,7 @@ export function LoginScreen() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100 p-4">
+    <div className="min-h-viewport flex items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100 p-4">
       <Card className="max-w-md w-full">
         <CardHeader className="text-center">
           <span className="material-symbols-outlined md-48 mx-auto mb-4 text-md3-primary">auto_awesome</span>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -355,7 +355,8 @@ function AIDiagnosticsPanel({ status }: { status: EngineStatus }) {
   return (
     <div className={`p-3 border rounded-lg ${bgClass}`}>
       {/* Header: Model info + current phase */}
-      <div className="flex items-center justify-between mb-2">
+      {/* 折り返し可。narrowなペーンではフェーズ名とモデル名が1行に収まらない。 */}
+      <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-1 mb-2">
         <div className="flex items-center gap-2">
           <span className={`material-symbols-outlined md-18 animate-spin ${textClass}`}>progress_activity</span>
           <span className={`text-body-sm font-medium ${textClass}`}>
@@ -2596,13 +2597,15 @@ export default function TextCorrectionApp() {
                 </div>
               ) : (
                 <div className="space-y-6">
-                  {/* Session Header */}
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <h2 className="text-headline-lg text-on-surface">{currentSession.name}</h2>
-                      <p className="text-metadata text-on-surface-variant">作成日: {currentSession.createdAt.toLocaleString()}</p>
+                  {/* Session Header。名前と計測値を1行に収めるには narrow端末の
+                      幅が足りず、以前は日時が右へはみ出していた。名前側を縮め
+                      させ、入り切らない計測値は次の行へ回す。 */}
+                  <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+                    <div className="min-w-0 flex-1">
+                      <h2 className="text-headline-lg text-on-surface truncate">{currentSession.name}</h2>
+                      <p className="text-metadata text-on-surface-variant truncate">作成日: {currentSession.createdAt.toLocaleString()}</p>
                     </div>
-                    <div className="flex items-center gap-3">
+                    <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
                       {/* レビュー作業時間タイマー＋平均（add-suggestion-generation-timer
                           改訂、design.md Decision 7）。LATESTはレビュー中のジョブの
                           累計レビュー時間（キュー待機/AI処理時間を含まない）。
@@ -2708,8 +2711,9 @@ export default function TextCorrectionApp() {
                           highlights={targetHighlights}
                         />
                         
-                        {/* Offline mode toggle */}
-                        <div className="flex items-center justify-between p-3 bg-surface-container border border-outline-variant rounded-lg">
+                        {/* Offline mode toggle。ラベルとバッジを1行に収めるには
+                            narrow端末の幅が足りないので折り返させる。 */}
+                        <div className="flex flex-wrap items-center justify-between gap-2 p-3 bg-surface-container border border-outline-variant rounded-lg">
                           <div className="flex items-center gap-2">
                             <Checkbox
                               id="offline-mode"

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2095,7 +2095,8 @@ export default function TextCorrectionApp() {
                 e.stopPropagation()
                 deleteSession(s.id)
               }}
-              className="opacity-0 group-hover:opacity-100 transition-opacity p-1 h-auto"
+              aria-label={`セッション「${s.name}」を削除`}
+              className="can-hover:opacity-0 can-hover:group-hover:opacity-100 transition-opacity p-1 h-auto touch-target"
             >
               <span className="material-symbols-outlined md-18 text-on-surface-variant">delete</span>
             </Button>
@@ -2213,7 +2214,7 @@ export default function TextCorrectionApp() {
         <button
           type="button"
           onClick={toggleSessionPane}
-          className="p-2 rounded-full hover:bg-surface-container transition-colors focus-visible:ring-2 focus-visible:ring-md3-primary"
+          className="p-2 rounded-full hover:bg-surface-container transition-colors focus-visible:ring-2 focus-visible:ring-md3-primary touch-target"
           title={
             isSessionPaneDocked
               ? 'セッション一覧をたたむ'
@@ -2295,7 +2296,7 @@ export default function TextCorrectionApp() {
           <div className="relative" ref={bellPanelRef}>
             <button
               type="button"
-              className={`p-2 rounded-full hover:bg-surface-container transition-colors relative ${bellShake ? 'bell-shake' : ''}`}
+              className={`p-2 rounded-full hover:bg-surface-container transition-colors relative touch-target ${bellShake ? 'bell-shake' : ''}`}
               title="完了通知"
               aria-label="完了通知"
               aria-expanded={bellPanelOpen}
@@ -2370,7 +2371,7 @@ export default function TextCorrectionApp() {
           {/* Settings (shared AI correction prompt) */}
           <button
             onClick={() => setPromptSettingsOpen(true)}
-            className="p-2 rounded-full hover:bg-surface-container transition-colors"
+            className="p-2 rounded-full hover:bg-surface-container transition-colors touch-target"
             title="設定"
             aria-label="設定"
           >
@@ -2394,7 +2395,7 @@ export default function TextCorrectionApp() {
           {/* Logout Button */}
           <button
             onClick={() => signOut()}
-            className="p-2 rounded-full hover:bg-surface-container transition-colors"
+            className="p-2 rounded-full hover:bg-surface-container transition-colors touch-target"
             title="ログアウト"
           >
             <span className="material-symbols-outlined md-24 text-on-surface-variant">logout</span>
@@ -2417,7 +2418,7 @@ export default function TextCorrectionApp() {
                 <button
                   type="button"
                   onClick={dockSessionPane}
-                  className="p-2 rounded-full hover:bg-surface-container transition-colors focus-visible:ring-2 focus-visible:ring-md3-primary"
+                  className="p-2 rounded-full hover:bg-surface-container transition-colors focus-visible:ring-2 focus-visible:ring-md3-primary touch-target"
                   title="セッション一覧を左に固定する"
                   aria-label="セッション一覧を左に固定する"
                 >
@@ -2533,8 +2534,9 @@ export default function TextCorrectionApp() {
                           </CardTitle>
                           <button
                             onClick={() => currentSession?.originalText && copyToClipboard(currentSession.originalText, "原文がクリップボードにコピーされました")}
-                            className="p-1.5 rounded hover:bg-surface-container transition-colors"
+                            className="p-1.5 rounded hover:bg-surface-container transition-colors touch-target"
                             title="コピー"
+                            aria-label="原文をコピー"
                           >
                             <span className="material-symbols-outlined md-18 text-on-surface-variant">content_copy</span>
                           </button>
@@ -2571,8 +2573,9 @@ export default function TextCorrectionApp() {
                           </CardTitle>
                           <button
                             onClick={() => currentSession?.targetText && copyToClipboard(currentSession.targetText, "添削対象テキストがクリップボードにコピーされました")}
-                            className="p-1.5 rounded hover:bg-surface-container transition-colors"
+                            className="p-1.5 rounded hover:bg-surface-container transition-colors touch-target"
                             title="コピー"
+                            aria-label="添削対象テキストをコピー"
                           >
                             <span className="material-symbols-outlined md-18 text-on-surface-variant">content_copy</span>
                           </button>
@@ -2858,7 +2861,7 @@ export default function TextCorrectionApp() {
                               ? 'bg-primary-container border-md3-primary'
                               : 'border-outline-variant hover:bg-surface-container'
                           }`}
-                          title="ダブルクリックで選択/選択解除"
+                          title="ダブルクリック、または右上の選択ボタンで選択/選択解除"
                         >
                           <div className="flex-1 min-w-0 space-y-2">
                             <div className="flex items-center justify-between">
@@ -2873,15 +2876,18 @@ export default function TextCorrectionApp() {
                                   </Badge>
                                 )}
                               </div>
-                              {/* Hover-reveal action icons */}
-                              <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                              {/* Quiet until hover on a mouse; always present on
+                                  touch, where the select button below is also
+                                  the single-tap alternative to double-click. */}
+                              <div className="flex items-center gap-1 can-hover:opacity-0 can-hover:group-hover:opacity-100 transition-opacity">
                                 <button
                                   onClick={(e) => {
                                     e.stopPropagation()
                                     copyToClipboard(`${suggestion.original}\n${suggestion.reason}`, "提案内容がクリップボードにコピーされました")
                                   }}
-                                  className="p-1 rounded hover:bg-surface-container-high"
+                                  className="p-1 rounded hover:bg-surface-container-high touch-target"
                                   title="コピー"
+                                  aria-label="この提案をコピー"
                                 >
                                   <span className="material-symbols-outlined md-18 text-on-surface-variant">content_copy</span>
                                 </button>
@@ -2890,8 +2896,10 @@ export default function TextCorrectionApp() {
                                     e.stopPropagation()
                                     toggleSuggestionSelection(suggestion.id)
                                   }}
-                                  className="p-1 rounded hover:bg-surface-container-high"
+                                  className="p-1 rounded hover:bg-surface-container-high touch-target"
                                   title={suggestion.selected ? "選択解除" : "選択"}
+                                  aria-label={suggestion.selected ? "この提案の選択を解除" : "この提案を選択"}
+                                  aria-pressed={suggestion.selected}
                                 >
                                   <span className={`material-symbols-outlined md-18 ${suggestion.selected ? 'text-session-complete' : 'text-on-surface-variant'}`}>
                                     {suggestion.selected ? 'check_circle' : 'radio_button_unchecked'}
@@ -3072,8 +3080,9 @@ export default function TextCorrectionApp() {
                                 <Button 
                                   variant={data.confirmed ? "ghost" : "outline"} 
                                   size="sm"
-                                  className="h-8 px-2"
+                                  className="h-8 px-2 touch-target"
                                   title="確認"
+                                  aria-label="この履歴を確認"
                                   onClick={(e) => {
                                     e.stopPropagation()
                                     handleRestore()
@@ -3086,8 +3095,9 @@ export default function TextCorrectionApp() {
                                 <Button
                                   variant="outline"
                                   size="sm"
-                                  className="h-8 px-2"
+                                  className="h-8 px-2 touch-target"
                                   title="アーカイブ"
+                                  aria-label="この履歴をアーカイブ"
                                   onClick={(e) => {
                                     e.stopPropagation()
                                     archiveHistoryRound(data, index)

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2192,7 +2192,7 @@ export default function TextCorrectionApp() {
   // 認証状態を確認中はローディング表示
   if (isAuthLoading) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-surface-container-low">
+      <div className="min-h-viewport flex items-center justify-center bg-surface-container-low">
         <span className="material-symbols-outlined md-48 animate-spin text-md3-primary">progress_activity</span>
       </div>
     )
@@ -2204,7 +2204,7 @@ export default function TextCorrectionApp() {
   }
 
   return (
-    <div className="h-screen flex flex-col bg-surface-container-low">
+    <div className="h-viewport flex flex-col bg-surface-container-low">
       {/* TopAppBar */}
       <header className="h-16 bg-surface border-b border-outline-variant flex items-center px-4 gap-4 flex-shrink-0 z-50">
         {/* Session pane trigger — 全ブレークポイントで常に見えるので一覧が
@@ -2406,8 +2406,11 @@ export default function TextCorrectionApp() {
           Sheetがバックドロップ・Esc・フォーカストラップ・トリガーへの
           フォーカス復帰を提供する（design.md Decision 2）。 */}
       <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
-        <SheetContent side="left" className="w-80 p-0 bg-surface">
-          <SheetHeader className="p-4 pr-12 border-b border-outline-variant">
+        {/* 320px端末では w-80 が画面幅と同じになり、閉じるための背景タップ域が
+            消えるので 85vw で頭打ちにする。高さはSheetが fixed inset-y-0 なので
+            ICB基準で、モバイルのブラウザUIを跨がない。 */}
+        <SheetContent side="left" className="w-[min(20rem,85vw)] p-0 bg-surface flex flex-col">
+          <SheetHeader className="p-4 pr-12 border-b border-outline-variant flex-shrink-0">
             <div className="flex items-center justify-between gap-2">
               <SheetTitle className="text-headline-md text-on-surface">セッション</SheetTitle>
               {isLgScreen && (
@@ -2425,9 +2428,11 @@ export default function TextCorrectionApp() {
               )}
             </div>
           </SheetHeader>
-          <div className="p-4">
-            <div className="mb-4">{sessionSearchInput}</div>
-            <ScrollArea className="h-[calc(100vh-12rem)]">{sessionListItems}</ScrollArea>
+          <div className="p-4 flex-1 min-h-0 flex flex-col">
+            <div className="mb-4 flex-shrink-0">{sessionSearchInput}</div>
+            {/* 高さはflexから導く。`calc(100vh-12rem)` はヘッダー等の高さを
+                決め打ちしていたため、ブラウザUIの分だけ下端が切れていた。 */}
+            <ScrollArea className="flex-1 min-h-0">{sessionListItems}</ScrollArea>
           </div>
         </SheetContent>
       </Sheet>
@@ -2455,8 +2460,8 @@ export default function TextCorrectionApp() {
             {/* Center Pane - Editor */}
             <main className="flex-1 overflow-y-auto p-4 lg:p-6">
               {!currentSession ? (
-                <div className="flex items-center justify-center min-h-[calc(100vh-8rem)]">
-                  <Card className="max-w-md w-full mx-4 bg-surface border-outline-variant">
+                <div className="flex items-center justify-center min-h-full">
+                  <Card className="max-w-md w-full bg-surface border-outline-variant">
                     <CardHeader className="text-center">
                       <span className="material-symbols-outlined md-48 mx-auto mb-4 text-md3-primary">description</span>
                       <CardTitle className="text-headline-md text-on-surface">セッションを開始</CardTitle>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -69,6 +69,14 @@ async function generateWebLLMSuggestions(
 
 type ActiveNav = 'sessions' | 'dashboard' | 'archive'
 
+// Rendered twice — as tabs in the top bar, and as rows in the session drawer
+// for the narrow viewports where the top bar has no room for them.
+const NAV_ITEMS: readonly { id: ActiveNav; label: string }[] = [
+  { id: 'sessions', label: 'Sessions' },
+  { id: 'dashboard', label: 'Dashboard' },
+  { id: 'archive', label: 'Archive' },
+]
+
 // Right pane resizing constants
 const RIGHT_PANE_MIN_WIDTH = 280 // px
 const RIGHT_PANE_MAX_WIDTH = 600 // px
@@ -2207,7 +2215,7 @@ export default function TextCorrectionApp() {
   return (
     <div className="h-viewport flex flex-col bg-surface-container-low">
       {/* TopAppBar */}
-      <header className="h-16 bg-surface border-b border-outline-variant flex items-center px-4 gap-4 flex-shrink-0 z-50">
+      <header className="h-16 bg-surface border-b border-outline-variant flex items-center px-3 sm:px-4 gap-2 sm:gap-4 flex-shrink-0 z-50">
         {/* Session pane trigger — 全ブレークポイントで常に見えるので一覧が
             迷子にならない。ドッキング中に押すとカラムをたたんで作業領域を
             広げ、フローティング中はオーバーレイを開閉する。 */}
@@ -2239,38 +2247,24 @@ export default function TextCorrectionApp() {
         {/* Logo/Title - Text wordmark only, no icon */}
         <h1 className="text-headline-lg text-on-surface">MJAI</h1>
 
-        {/* Navigation Tabs */}
-        <nav className="flex items-center gap-1 ml-4">
-          <button
-            onClick={() => setActiveNav('sessions')}
-            className={`px-4 py-2 text-body-sm rounded-lg transition-colors ${
-              activeNav === 'sessions'
-                ? 'bg-primary-container text-on-primary-container font-semibold'
-                : 'text-on-surface-variant hover:bg-surface-container font-normal'
-            }`}
-          >
-            Sessions
-          </button>
-          <button
-            onClick={() => setActiveNav('dashboard')}
-            className={`px-4 py-2 text-body-sm rounded-lg transition-colors ${
-              activeNav === 'dashboard'
-                ? 'bg-primary-container text-on-primary-container font-semibold'
-                : 'text-on-surface-variant hover:bg-surface-container font-normal'
-            }`}
-          >
-            Dashboard
-          </button>
-          <button
-            onClick={() => setActiveNav('archive')}
-            className={`px-4 py-2 text-body-sm rounded-lg transition-colors ${
-              activeNav === 'archive'
-                ? 'bg-primary-container text-on-primary-container font-semibold'
-                : 'text-on-surface-variant hover:bg-surface-container font-normal'
-            }`}
-          >
-            Archive
-          </button>
+        {/* Navigation Tabs — below md the bar cannot hold three of these plus
+            the account and action icons, so they move into the session drawer
+            rather than overflowing off the right edge. */}
+        <nav className="hidden md:flex items-center gap-1 ml-4" aria-label="セクション">
+          {NAV_ITEMS.map((item) => (
+            <button
+              key={item.id}
+              onClick={() => setActiveNav(item.id)}
+              aria-current={activeNav === item.id ? 'page' : undefined}
+              className={`px-4 py-2 text-body-sm rounded-lg transition-colors ${
+                activeNav === item.id
+                  ? 'bg-primary-container text-on-primary-container font-semibold'
+                  : 'text-on-surface-variant hover:bg-surface-container font-normal'
+              }`}
+            >
+              {item.label}
+            </button>
+          ))}
         </nav>
 
         {/* New Session Button */}
@@ -2378,28 +2372,33 @@ export default function TextCorrectionApp() {
             <span className="material-symbols-outlined md-24 text-on-surface-variant">settings</span>
           </button>
 
-          {/* User Avatar */}
-          {avatarUrl ? (
-            <Image
-              src={avatarUrl}
-              alt="User avatar"
-              width={32}
-              height={32}
-              className="rounded-full border border-outline-variant"
-              unoptimized
-            />
-          ) : (
-            <span className="material-symbols-outlined md-24 text-on-surface-variant">account_circle</span>
-          )}
+          {/* Identity and sign-out. Below sm this is the pair that has to give
+              way for the bar to fit a 320px screen, so it moves to the foot of
+              the session drawer — where a phone's account controls usually are
+              anyway — rather than being dropped. */}
+          <div className="hidden sm:flex items-center gap-2">
+            {avatarUrl ? (
+              <Image
+                src={avatarUrl}
+                alt="User avatar"
+                width={32}
+                height={32}
+                className="rounded-full border border-outline-variant"
+                unoptimized
+              />
+            ) : (
+              <span className="material-symbols-outlined md-24 text-on-surface-variant">account_circle</span>
+            )}
 
-          {/* Logout Button */}
-          <button
-            onClick={() => signOut()}
-            className="p-2 rounded-full hover:bg-surface-container transition-colors touch-target"
-            title="ログアウト"
-          >
-            <span className="material-symbols-outlined md-24 text-on-surface-variant">logout</span>
-          </button>
+            <button
+              onClick={() => signOut()}
+              className="p-2 rounded-full hover:bg-surface-container transition-colors touch-target"
+              title="ログアウト"
+              aria-label="ログアウト"
+            >
+              <span className="material-symbols-outlined md-24 text-on-surface-variant">logout</span>
+            </button>
+          </div>
         </div>
       </header>
 
@@ -2429,11 +2428,64 @@ export default function TextCorrectionApp() {
               )}
             </div>
           </SheetHeader>
+          {/* セクション切り替え。md未満ではトップバーにタブを置く幅がないため、
+              一覧と同じドロワーが行き先になる（design.md Decision 5）。選択後は
+              ドロワーが本文を覆い続けないよう閉じる。 */}
+          <nav
+            className="md:hidden px-4 pt-4 flex flex-col gap-1 flex-shrink-0"
+            aria-label="セクション"
+          >
+            {NAV_ITEMS.map((item) => (
+              <button
+                key={item.id}
+                onClick={() => {
+                  setActiveNav(item.id)
+                  setSidebarOpen(false)
+                }}
+                aria-current={activeNav === item.id ? 'page' : undefined}
+                className={`px-3 py-2.5 text-body-sm rounded-lg text-left transition-colors ${
+                  activeNav === item.id
+                    ? 'bg-primary-container text-on-primary-container font-semibold'
+                    : 'text-on-surface-variant hover:bg-surface-container font-normal'
+                }`}
+              >
+                {item.label}
+              </button>
+            ))}
+          </nav>
           <div className="p-4 flex-1 min-h-0 flex flex-col">
             <div className="mb-4 flex-shrink-0">{sessionSearchInput}</div>
             {/* 高さはflexから導く。`calc(100vh-12rem)` はヘッダー等の高さを
                 決め打ちしていたため、ブラウザUIの分だけ下端が切れていた。 */}
             <ScrollArea className="flex-1 min-h-0">{sessionListItems}</ScrollArea>
+          </div>
+          {/* sm未満でトップバーから外したアカウント操作の行き先。 */}
+          <div className="sm:hidden border-t border-outline-variant p-4 flex items-center gap-3 flex-shrink-0">
+            {avatarUrl ? (
+              <Image
+                src={avatarUrl}
+                alt="User avatar"
+                width={32}
+                height={32}
+                className="rounded-full border border-outline-variant flex-shrink-0"
+                unoptimized
+              />
+            ) : (
+              <span className="material-symbols-outlined md-24 text-on-surface-variant flex-shrink-0">
+                account_circle
+              </span>
+            )}
+            <span className="text-body-sm text-on-surface-variant truncate min-w-0 flex-1">
+              {user?.email ?? ''}
+            </span>
+            <button
+              onClick={() => signOut()}
+              className="p-2 rounded-full hover:bg-surface-container transition-colors touch-target flex-shrink-0"
+              title="ログアウト"
+              aria-label="ログアウト"
+            >
+              <span className="material-symbols-outlined md-24 text-on-surface-variant">logout</span>
+            </button>
           </div>
         </SheetContent>
       </Sheet>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -453,6 +453,10 @@ export default function TextCorrectionApp() {
   const [rightPaneWidth, setRightPaneWidth] = useState(RIGHT_PANE_DEFAULT_WIDTH)
   const [isResizing, setIsResizing] = useState(false)
   const [isLgScreen, setIsLgScreen] = useState(false)
+  // Below lg there is not enough width to show the editor and the review panes
+  // side by side, and not enough height to stack them, so only one is on screen
+  // at a time (design.md Decision 3). Ignored at lg and above, where both are.
+  const [mobilePane, setMobilePane] = useState<'editor' | 'review'>('editor')
   // Hover-preview trigger for suggestion-card text-span highlighting
   // (see highlight-suggestion-text-spans design.md Decision 2).
   const [hoveredSuggestionId, setHoveredSuggestionId] = useState<string | null>(null)
@@ -1223,6 +1227,11 @@ export default function TextCorrectionApp() {
       currentSession.suggestions.length > 0
     ) {
       lastScrolledJobIdRef.current = confirmingJobId
+      // Below lg the suggestions card is not merely further down the page, it is
+      // in the pane that is currently hidden — so bringing it into view means
+      // switching panes first. The scroll below then still positions the card
+      // within that pane.
+      setMobilePane('review')
       // Small delay to ensure DOM is updated after React render
       const timeoutId = setTimeout(() => {
         const suggestionsCard = document.querySelector('[data-suggestions-card]')
@@ -1236,6 +1245,12 @@ export default function TextCorrectionApp() {
     // reference, to avoid re-scrolling on every selection/edit (see comment above)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [confirmingJobId, currentSession?.suggestions?.length])
+
+  // A pane choice belongs to the session it was made in: carrying "review" over
+  // to a session with nothing to review would open on an empty pane.
+  useEffect(() => {
+    setMobilePane('editor')
+  }, [currentSessionId])
 
   // 「実際にレビュー作業をしている」ジョブID（add-suggestion-generation-timer
   // 改訂、design.md Decision 7）。以下の全てを満たす場合のみ非nullになる:
@@ -2138,6 +2153,9 @@ export default function TextCorrectionApp() {
   // Job Queueと同じヘルパーを使い「最新」の定義が2箇所でズレないようにする。
   const completedJobs = useMemo(() => sortCompletedJobsNewestFirst(jobQueue), [jobQueue])
   const completedJobCount = completedJobs.length
+  // Shown on the pane switch below lg, where the review pane is off screen: the
+  // proposals under review, or failing that the work that will produce them.
+  const reviewPaneCount = currentSession?.suggestions?.length || activeJobCount
 
   // 生成タイマー表示用の派生値（add-suggestion-generation-timer改訂、design.md
   // Decision 7参照）。「最新」はキュー待機/AI処理時間を含まない、レビュー
@@ -2510,8 +2528,55 @@ export default function TextCorrectionApp() {
 
           {/* Center + Right Pane Container */}
           <div className="flex-1 flex flex-col lg:flex-row min-h-0 overflow-hidden">
+            {/* Pane switch — only below lg, where one pane is on screen at a
+                time. Rendered inside the flex-col container so it takes its own
+                row above whichever pane is showing, and removed from layout at
+                lg where both panes are visible and the switch would be a lie. */}
+            {currentSession && (
+              <div
+                className="lg:hidden flex-shrink-0 flex gap-1 border-b border-outline-variant bg-surface px-3 py-2"
+                role="group"
+                aria-label="表示するペーン"
+              >
+                <button
+                  type="button"
+                  onClick={() => setMobilePane('editor')}
+                  aria-pressed={mobilePane === 'editor'}
+                  className={`flex-1 rounded-lg px-3 py-2 text-body-sm transition-colors ${
+                    mobilePane === 'editor'
+                      ? 'bg-primary-container text-on-primary-container font-semibold'
+                      : 'text-on-surface-variant hover:bg-surface-container font-normal'
+                  }`}
+                >
+                  編集
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setMobilePane('review')}
+                  aria-pressed={mobilePane === 'review'}
+                  className={`flex-1 rounded-lg px-3 py-2 text-body-sm transition-colors inline-flex items-center justify-center gap-1.5 ${
+                    mobilePane === 'review'
+                      ? 'bg-primary-container text-on-primary-container font-semibold'
+                      : 'text-on-surface-variant hover:bg-surface-container font-normal'
+                  }`}
+                >
+                  添削案
+                  {/* What is waiting in the pane you cannot currently see. */}
+                  {reviewPaneCount > 0 && (
+                    <Badge className="bg-surface-container text-on-surface-variant text-xs font-medium">
+                      {reviewPaneCount}
+                    </Badge>
+                  )}
+                </button>
+              </div>
+            )}
+
             {/* Center Pane - Editor */}
-            <main className="flex-1 overflow-y-auto p-4 lg:p-6">
+            <main
+              className={`flex-1 min-h-0 overflow-y-auto p-4 lg:p-6 ${
+                mobilePane === 'editor' ? 'block' : 'hidden'
+              } lg:block`}
+            >
               {!currentSession ? (
                 <div className="flex items-center justify-center min-h-full">
                   <Card className="max-w-md w-full bg-surface border-outline-variant">
@@ -2734,8 +2799,10 @@ export default function TextCorrectionApp() {
             </div>
 
             {/* Right Pane - Job Queue + Suggestions (Desktop: side panel with resizable width, Mobile: below editor) */}
-            <aside 
-              className="w-full lg:flex-shrink-0 bg-surface border-t lg:border-t-0 border-outline-variant overflow-y-auto"
+            <aside
+              className={`w-full flex-1 min-h-0 lg:flex-none bg-surface border-outline-variant overflow-y-auto ${
+                mobilePane === 'review' ? 'block' : 'hidden'
+              } lg:block`}
               style={isLgScreen ? { width: rightPaneWidth } : undefined}
             >
               <div className="p-4 lg:p-6 space-y-card-gap">

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2756,7 +2756,8 @@ export default function TextCorrectionApp() {
                           <AIDiagnosticsPanel status={webllmStatus} />
                         )}
                         
-                        {/* Generate Button */}
+                        {/* Generate Button。narrow端末では中央に置いた小さな的を
+                            狙わせるより、幅いっぱいのほうが親指で押しやすい。 */}
                         <div className="flex justify-center">
                           <Button
                             onClick={handleGenerateClick}
@@ -2765,7 +2766,7 @@ export default function TextCorrectionApp() {
                               !currentSession.originalText.trim() ||
                               (offlineMode && webgpuSupported === false)
                             }
-                            className="bg-on-surface text-surface hover:bg-on-surface/90 rounded-full px-6 py-2"
+                            className="w-full sm:w-auto bg-on-surface text-surface hover:bg-on-surface/90 rounded-full px-6 py-2"
                           >
                             {(() => {
                               const processingCount = jobQueue.filter(j => j.status === 'processing').length

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2601,7 +2601,12 @@ export default function TextCorrectionApp() {
                       幅が足りず、以前は日時が右へはみ出していた。名前側を縮め
                       させ、入り切らない計測値は次の行へ回す。 */}
                   <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
-                    <div className="min-w-0 flex-1">
+                    {/* `basis-48` gives the name a width it is willing to fight
+                        for: with a zero basis it would always yield and be
+                        truncated to a few characters, when the session name is
+                        what identifies the work and the timings are short. Below
+                        that width the timings wrap to their own line instead. */}
+                    <div className="min-w-0 flex-1 basis-48">
                       <h2 className="text-headline-lg text-on-surface truncate">{currentSession.name}</h2>
                       <p className="text-metadata text-on-surface-variant truncate">作成日: {currentSession.createdAt.toLocaleString()}</p>
                     </div>

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -58,7 +58,9 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+      {/* A 16px glyph is not a finger-sized target, so `touch-target` gives it
+          the 44px minimum where the pointer cannot hover. */}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none touch-target">
         <X className="h-4 w-4" />
         <span className="sr-only">閉じる</span>
       </DialogPrimitive.Close>

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -42,7 +42,17 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-1/2 top-1/2 z-50 flex max-h-[90vh] w-[calc(100vw-2rem)] max-w-3xl -translate-x-1/2 -translate-y-1/2 flex-col gap-4 rounded-lg border border-outline-variant bg-surface p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        // `max-h-[90%]` rather than `90vh`: this element is `fixed`, so a
+        // percentage resolves against the initial containing block, which is
+        // the viewport the browser is actually showing (and which shrinks for
+        // the on-screen keyboard — see layout.tsx `interactiveWidget`). `vh`
+        // reports the largest possible viewport, so on a phone the dialog's
+        // footer ended up below the fold with nothing to scroll it into view.
+        // `overflow-y-auto` is the backstop for the case the two above cannot
+        // cover: once a flexible child has shrunk to its own floor there is
+        // nothing left to give, and without a scroll the footer's buttons would
+        // simply be unreachable.
+        "fixed left-1/2 top-1/2 z-50 flex max-h-[90%] w-[calc(100vw-2rem)] max-w-3xl -translate-x-1/2 -translate-y-1/2 flex-col gap-4 overflow-y-auto rounded-lg border border-outline-variant bg-surface p-4 sm:p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
         className
       )}
       {...props}

--- a/frontend/src/components/ui/exemplar-text-card.tsx
+++ b/frontend/src/components/ui/exemplar-text-card.tsx
@@ -73,7 +73,10 @@ export function ExemplarTextCard({
             >
               expand_more
             </span>
-            <CardTitle className="text-label-caps tracking-wider text-on-surface-variant uppercase">
+            {/* Truncates rather than pushing the row wider: the heading is fixed
+                text the user can predict, where the badges beside it are the
+                part that says something about their own input. */}
+            <CardTitle className="min-w-0 truncate text-label-caps tracking-wider text-on-surface-variant uppercase">
               EXEMPLAR TEXT (模範回答訳文)
               <span className="ml-2 normal-case tracking-normal text-metadata text-on-surface-variant/70">
                 任意

--- a/frontend/src/components/ui/exemplar-text-card.tsx
+++ b/frontend/src/components/ui/exemplar-text-card.tsx
@@ -95,8 +95,9 @@ export function ExemplarTextCard({
           {onCopy && (
             <button
               onClick={() => value && onCopy(value)}
-              className="p-1.5 rounded hover:bg-surface-container transition-colors shrink-0"
+              className="p-1.5 rounded hover:bg-surface-container transition-colors shrink-0 touch-target"
               title="コピー"
+              aria-label="模範回答訳文をコピー"
             >
               <span className="material-symbols-outlined md-18 text-on-surface-variant">
                 content_copy

--- a/frontend/src/components/ui/job-queue-carousel.tsx
+++ b/frontend/src/components/ui/job-queue-carousel.tsx
@@ -156,7 +156,7 @@ export function JobQueueCarousel<T>({
               aria-label="前のジョブへ"
               disabled={!canScrollPrev}
               onClick={() => scrollByPage(-1)}
-              className="p-1 rounded-full text-on-surface-variant hover:bg-surface-container transition-colors disabled:opacity-50 disabled:cursor-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-md3-primary"
+              className="p-1 rounded-full text-on-surface-variant hover:bg-surface-container transition-colors disabled:opacity-50 disabled:cursor-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-md3-primary touch-target"
             >
               <span className="material-symbols-outlined md-20">chevron_left</span>
             </button>
@@ -165,7 +165,7 @@ export function JobQueueCarousel<T>({
               aria-label="次のジョブへ"
               disabled={!canScrollNext}
               onClick={() => scrollByPage(1)}
-              className="p-1 rounded-full text-on-surface-variant hover:bg-surface-container transition-colors disabled:opacity-50 disabled:cursor-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-md3-primary"
+              className="p-1 rounded-full text-on-surface-variant hover:bg-surface-container transition-colors disabled:opacity-50 disabled:cursor-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-md3-primary touch-target"
             >
               <span className="material-symbols-outlined md-20">chevron_right</span>
             </button>

--- a/frontend/src/components/ui/prompt-settings-dialog.tsx
+++ b/frontend/src/components/ui/prompt-settings-dialog.tsx
@@ -163,7 +163,11 @@ export function PromptSettingsDialog({
           }}
           disabled={isLoading || isSaving}
           spellCheck={false}
-          className="min-h-[45vh] max-h-[55vh] overflow-y-auto font-mono text-body-sm leading-relaxed bg-surface-container border-outline-variant"
+          // Takes whatever height the dialog has left rather than claiming a
+          // share of the viewport: `45vh`/`55vh` ignored the header, footer and
+          // counters above and below it, which on a phone with the keyboard open
+          // pushed the save button out of the dialog entirely.
+          className="flex-1 min-h-[8rem] overflow-y-auto font-mono text-body-sm leading-relaxed bg-surface-container border-outline-variant"
         />
 
         <div className="flex items-center justify-between gap-2 flex-wrap">

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -64,7 +64,8 @@ const SheetContent = React.forwardRef<
       className={cn(sheetVariants({ side }), className)}
       {...props}
     >
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+      {/* `touch-target`: a 16px glyph is not a finger-sized target. */}
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary touch-target">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </SheetPrimitive.Close>

--- a/frontend/src/components/ui/toast.tsx
+++ b/frontend/src/components/ui/toast.tsx
@@ -77,7 +77,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      "absolute right-1 top-1 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-1 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      "absolute right-1 top-1 rounded-md p-1 text-foreground/50 can-hover:opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-1 can-hover:group-hover:opacity-100 touch-target group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
       className
     )}
     toast-close=""

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,3 +1,25 @@
+const plugin = require('tailwindcss/plugin')
+
+/**
+ * `can-hover:` — only where the pointer can actually hover.
+ *
+ * Keyed on what the pointer can do, not on how wide the screen is: a narrow
+ * window on a laptop can still hover, and a 1280px tablet cannot, so a
+ * breakpoint would get both of those wrong.
+ *
+ * Its purpose is to make hiding an action until hover safe. Because the variant
+ * does not apply to the base class, a reveal written as
+ * `can-hover:opacity-0 can-hover:group-hover:opacity-100` is visible by
+ * default and quiet only where there is a pointer to reveal it.
+ *
+ * The counterpart — a finger-sized target where the pointer cannot hover — is
+ * `.touch-target` in globals.css, which needs centering as well as a minimum
+ * size and so is more than a variant can express.
+ */
+const pointerCapabilityVariants = plugin(function ({ addVariant }) {
+  addVariant('can-hover', '@media (hover: hover) and (pointer: fine)')
+})
+
 module.exports = {
     darkMode: ["class"],
     content: [
@@ -100,5 +122,5 @@ module.exports = {
   		}
   	}
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [require("tailwindcss-animate"), pointerCapabilityVariants],
 }

--- a/openspec/changes/responsive-mobile-correction-ui/.openspec.yaml
+++ b/openspec/changes/responsive-mobile-correction-ui/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-16

--- a/openspec/changes/responsive-mobile-correction-ui/design.md
+++ b/openspec/changes/responsive-mobile-correction-ui/design.md
@@ -61,9 +61,13 @@ The switch does not fire on generation *start*. A job takes 10–20 seconds duri
 
 ### 5. Section tabs move into the drawer below `md`, and only below `md`
 
-The tabs (`Sessions` / `Dashboard` / `Archive`, the latter two currently placeholders) are the widest discardable thing in the top bar. Below `md` they render in the session drawer, which is already the "where am I" surface, and the top bar keeps the menu trigger, wordmark, new-session and the icon cluster — which fits 320px. `md` rather than `lg` because the tabs *do* fit a 768px tablet top bar, and the drawer copy is rendered `md:hidden` so the two never both exist.
+The tabs (`Sessions` / `Dashboard` / `Archive`, the latter two currently placeholders) are the widest discardable thing in the top bar. Below `md` they render in the session drawer, which is already the "where am I" surface. `md` rather than `lg` because the tabs *do* fit a 768px tablet top bar, and the drawer copy is rendered `md:hidden` so the two never both exist.
 
-Alternative: an overflow "…" menu for the icon cluster. Rejected: it hides sign-out and settings behind an extra tap to save width that moving three placeholder tabs already frees.
+Moving the tabs alone does not reach 320px. Measured, the remainder still wants ~385px: menu 44, wordmark ~65, new-session 36, and a four-icon cluster (bell, settings, avatar, sign-out) at ~188 including gaps. Identity and sign-out therefore follow below `sm`, to the foot of the same drawer — which is where a phone's account controls usually live — leaving the menu trigger, the wordmark and the three things a correction session needs at hand: new session, notifications, settings. With `px-3`/`gap-2` at that size the row fits 320px with roughly 35px to spare.
+
+Both moves are a single `NAV_ITEMS` array rendered in two places rather than two hand-maintained copies, since three buttons duplicated by hand is what drifts.
+
+Alternative: an overflow "…" menu for the icon cluster. Rejected: it hides settings behind an extra tap, and the drawer is a better home than a second disclosure for controls that are not part of the correction loop.
 
 ### 6. Viewport height from `dvh`, with a fallback that is not decoration
 
@@ -87,9 +91,19 @@ By default only the visual viewport shrinks when the on-screen keyboard opens, s
 
 `h-[calc(100vh-12rem)]` on the drawer's session list and `min-h-[calc(100vh-8rem)]` on the empty-session state encode a guess about how much chrome is above them. Both become flex-derived (`flex-1` inside a column, `min-h-full`), which is correct at every viewport and cannot drift when the header changes height.
 
+The prompt dialog had the same shape of problem in `vh` form: a `45vh`/`55vh` textarea that ignored the header, footer and counters around it, so with the keyboard open the save button left the dialog. It becomes `flex-1` with a floor, inside a dialog bounded by `max-h-[90%]` — a percentage, because the dialog is `fixed` and so resolves against the initial containing block, which is the visible viewport — with `overflow-y-auto` as the backstop for when a flexible child has already shrunk to its floor.
+
+### 10. Rows that cannot fit wrap, with the sacrifice chosen per row
+
+Four rows are laid out as one line whose contents need more than 320px: the session heading beside its timing readouts, the offline-mode label beside its provider badge, the diagnostics phase beside the model name, and the exemplar heading beside its "input present" badges. Each gets `flex-wrap`, and what yields is decided per row rather than uniformly.
+
+The session name shrinks and truncates but is given a basis (`basis-48`) it will fight for, so the short fixed readouts wrap to their own line rather than the name being cut to a few characters — the name is what identifies the work. The exemplar heading truncates for the mirror-image reason: it is fixed text the user can predict, where the badges beside it describe their own input.
+
 ### 9. Test what jsdom can actually answer
 
-jsdom evaluates no media queries and lays nothing out, so a test cannot assert that a control is visible at 375px. What it can assert is the part that is real logic: which pane is rendered for a given `mobilePane`, that reviewing a job switches it, that the switch is absent from the desktop path, and that the classes carrying the responsive contract are present. A `matchMedia` stub plus a viewport helper is added for the code that reads `window.innerWidth`. Anything that depends on real layout is verified by hand in a device-sized browser and recorded, not asserted in jsdom — a passing test that cannot fail is worse than no test.
+jsdom evaluates no media queries and lays nothing out, so a test cannot assert that a control is visible at 375px. What it can assert is the part that is not CSS: the switch's own state, that opening a job for review moves it, that it reports the count waiting in the pane the user cannot see, and that it is absent before a session exists. Anything that depends on real layout is verified by hand in a device-sized browser and recorded, not asserted in jsdom — a passing test that cannot fail is worse than no test.
+
+No `matchMedia` stub or viewport helper turned out to be needed, because Decision 3 leaves the breakpoint entirely to CSS: nothing in the pane switch reads a viewport width. Asserting on the `hidden` / `lg:block` class strings was also dropped — it would restate the implementation without being able to detect the failure that matters, which is CSS not resolving the way the class names imply.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/responsive-mobile-correction-ui/design.md
+++ b/openspec/changes/responsive-mobile-correction-ui/design.md
@@ -1,0 +1,109 @@
+## Context
+
+See proposal.md — Why for the failures being fixed. The constraints that shape the approach:
+
+- `page.tsx` is one ~3,100-line client component. Its authenticated tree is `header` → optional session `aside` → a `flex-1 flex flex-col lg:flex-row min-h-0 overflow-hidden` container holding `main` (editor) and `aside` (job queue + suggestions + history). Restructuring that tree is the main risk in this change, so the design avoids moving JSX.
+- `lg` (1024px) is already the only layout breakpoint, and `LG_BREAKPOINT_PX` in `lib/uiPreferences.ts` mirrors it for the JS that sizes the right pane. Introducing a second layout breakpoint would mean two sources of truth for the same split.
+- `globals.css` clips horizontal overflow on `html, body`. That is what turns a too-wide top bar from an ugly scroll into unreachable controls, and it is worth keeping (a workspace that scrolls sideways by accident is worse), so the top bar has to fit rather than overflow.
+- Tailwind is 3.4.17: `dvh` utilities exist, and `addVariant` plugins are available. `tailwindcss-animate` is the only plugin today.
+- `layout.tsx` is a Server Component with no `viewport` export, so Next injects the default `width=device-width, initial-scale=1`.
+- `next.config.js` sets `output: 'export'`, so anything added must be static-render safe.
+- Jest is jsdom with no `matchMedia` and no configured viewport. jsdom does not evaluate media queries or lay anything out, which bounds what these tests can honestly assert.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make every control reachable and every core action performable with a finger, at 320px.
+- Give the review step the full screen when it is the step the user is on.
+- Leave the desktop layout, density and hover behavior byte-for-byte as they are.
+- Keep the change surgical: class and attribute edits plus one new piece of state, not a re-layout of `page.tsx`.
+
+**Non-Goals:**
+
+- Splitting `page.tsx` into components. It needs doing, but bundling it with a behavior change would make both unreviewable.
+- A mobile-first rewrite of the 58 files that carry no responsive styling. Most are primitives that inherit their width; this change touches only the ones that actually misbehave.
+- Bottom tab bars, gesture navigation, pull-to-refresh, or any other app-shell convention beyond what the two panes need.
+- Side-by-side 原文 / 添削対象 on tablets. They are stacked at every width today, and stacking is right for the long CJK lines this app handles.
+
+## Decisions
+
+### 1. Pointer capability, not viewport width, decides touch affordances
+
+Two Tailwind variants added via `addVariant`:
+
+- `can-hover` → `@media (hover: hover) and (pointer: fine)`
+- `touch` → `@media (hover: none)`
+
+A hover-revealed action becomes `can-hover:opacity-0 can-hover:group-hover:opacity-100` instead of `opacity-0 group-hover:opacity-100`. The default (no variant) is "visible", so anything that cannot hover sees the action; a mouse still gets the quiet card. Tap targets become `touch:min-h-11 touch:min-w-11`, which leaves desktop sizes untouched.
+
+Alternatives: gate on `lg:` — rejected, because it makes a narrow desktop window lose hover reveal it can use, and a 1280px-wide tablet keep affordances it cannot. Detect touch in JS and branch — rejected, because it needs a mount-time effect and re-render for something CSS answers directly, and `output: 'export'` means the first paint is static.
+
+### 2. The double-click selection route stays, and stops being the only route
+
+`onDoubleClick` on the suggestion card is kept for desktop, where it is a genuinely fast way to work through a list. What changes is that the always-visible-on-touch select button from Decision 1 is now a real single-activation route, which is what the spec requires. This is why Decision 1 comes first: it is the mechanism, and single-tap selection is a consequence of it rather than a second implementation.
+
+Alternative: replace double-click with single-click on the card body. Rejected — the card contains a textarea, badges and a copy button, so a body-wide click target fights its own contents, and the existing `stopPropagation` dance would have to grow.
+
+### 3. Below `lg`, one pane at a time — by visibility, not by moving JSX
+
+New state `mobilePane: 'editor' | 'review'`, and `main` / `aside` each get a conditional `hidden lg:…` class. Nothing moves in the tree, so the desktop render path is provably unchanged and the diff stays reviewable. The switch itself is a two-button segmented control rendered `lg:hidden` directly under the header.
+
+This also repairs the height fight described in proposal.md: with only one pane visible below `lg`, `flex-1` has a single claimant, so each pane gets the whole area and one scroll region instead of two competing ones. `aside` gains `flex-1 lg:flex-none` for that reason.
+
+Alternatives: let the whole document scroll below `lg` (drop the inner scroll containers) — simpler and needs no new state, but leaves a single scroll of roughly editor + queue + 10–20 suggestion cards + history, which is the complaint, not the fix. An accordion of collapsible sections — more taps for the same information and it does not give the review list a full screen.
+
+### 4. The pane switch reuses the existing "take the user to the suggestions" intent
+
+`page.tsx` already has an effect that scrolls `[data-suggestions-card]` into view when `confirmingJobId` changes and suggestions have loaded, deliberately keyed on `suggestions.length` so selection edits do not re-trigger it. Below `lg` that element is now inside a hidden pane, where `scrollIntoView` is a silent no-op. Rather than add a second trigger, the same effect sets `mobilePane = 'review'`. One place decides "the user is now reviewing this job", and it keeps working for the job queue and the notification list without either of them knowing about panes.
+
+The switch does not fire on generation *start*. A job takes 10–20 seconds during which the user may keep editing, and yanking the pane out from under them would be worse than the count badge that tells them something is waiting.
+
+### 5. Section tabs move into the drawer below `md`, and only below `md`
+
+The tabs (`Sessions` / `Dashboard` / `Archive`, the latter two currently placeholders) are the widest discardable thing in the top bar. Below `md` they render in the session drawer, which is already the "where am I" surface, and the top bar keeps the menu trigger, wordmark, new-session and the icon cluster — which fits 320px. `md` rather than `lg` because the tabs *do* fit a 768px tablet top bar, and the drawer copy is rendered `md:hidden` so the two never both exist.
+
+Alternative: an overflow "…" menu for the icon cluster. Rejected: it hides sign-out and settings behind an extra tap to save width that moving three placeholder tabs already frees.
+
+### 6. Viewport height from `dvh`, with a fallback that is not decoration
+
+Two utilities in `globals.css` rather than Tailwind's `h-dvh`:
+
+```css
+.h-viewport { height: 100vh; height: 100dvh; }
+```
+
+Tailwind can emit both `h-screen` and `h-dvh`, but which one wins depends on utility ordering in the generated sheet, which is not something to rely on for the shell's height. The declaration pair is deterministic. The `vh` line matters: without any height the shell is a flex column of auto-height panes, which collapses rather than degrading.
+
+### 7. The keyboard gets to resize the layout viewport
+
+`layout.tsx` gains `export const viewport = { width: 'device-width', initialScale: 1, interactiveWidget: 'resizes-content' }`.
+
+By default only the visual viewport shrinks when the on-screen keyboard opens, so `dvh` keeps reporting the full height and the field being typed into can sit behind the keyboard. `resizes-content` shrinks the layout viewport too, so `dvh` follows the keyboard and Decision 6 does the rest. Supported in Chrome 108+ and Firefox 132+; elsewhere it is ignored and behavior is today's.
+
+`maximumScale` and `userScalable` are deliberately absent — suppressing zoom is the standard collateral damage of a mobile pass, and the spec forbids it.
+
+### 8. Drop `vh` arithmetic where flex already knows the answer
+
+`h-[calc(100vh-12rem)]` on the drawer's session list and `min-h-[calc(100vh-8rem)]` on the empty-session state encode a guess about how much chrome is above them. Both become flex-derived (`flex-1` inside a column, `min-h-full`), which is correct at every viewport and cannot drift when the header changes height.
+
+### 9. Test what jsdom can actually answer
+
+jsdom evaluates no media queries and lays nothing out, so a test cannot assert that a control is visible at 375px. What it can assert is the part that is real logic: which pane is rendered for a given `mobilePane`, that reviewing a job switches it, that the switch is absent from the desktop path, and that the classes carrying the responsive contract are present. A `matchMedia` stub plus a viewport helper is added for the code that reads `window.innerWidth`. Anything that depends on real layout is verified by hand in a device-sized browser and recorded, not asserted in jsdom — a passing test that cannot fail is worse than no test.
+
+## Risks / Trade-offs
+
+- **The pane switch is a new concept for existing (desktop) users** → It renders only below `lg`, where the alternative today is a broken split. Desktop sees nothing new.
+- **Auto-switching panes on job review could surprise someone mid-edit** → It fires only when the user opened a job for review, which is an explicit request to look at suggestions; it does not fire on generation start.
+- **`can-hover` / `touch` variants could be applied inconsistently as the UI grows** → They are named for the capability they test, and the two are mutually exclusive, so a reviewer can see at a glance which branch a class belongs to. Documented in `docs/UI-DESIGN.md`.
+- **`interactiveWidget` is unsupported on Safari** → Its absence is exactly today's behavior, and Decision 6 still keeps the shell inside the visible viewport; only the keyboard case is left unimproved there.
+- **jsdom tests cannot prove the layout works** → Stated plainly above; the real check is manual on a device-sized viewport, and it is a task, not an afterthought.
+- **`page.tsx` grows again** → About 40 lines for the switch and its state. The file needs splitting, but not in the same change as a behavior fix (Non-Goals).
+
+## Migration Plan
+
+Frontend-only, no schema or environment change. `NEXT_PUBLIC_*` values are untouched, so no rebuild beyond the normal Vercel build on merge. Rollback is a revert of the commit range: nothing persists new state (`mobilePane` is in-memory, deliberately not in localStorage — a stored pane would reopen the app on the review tab of a session the user has since left).
+
+## Open Questions
+
+None that change the specs or the task breakdown. Whether the pane switch should also appear on tablet-width landscape (where 1024px is met but the right pane is cramped) is worth revisiting after the manual pass, and would be a follow-up adjustment of one breakpoint.

--- a/openspec/changes/responsive-mobile-correction-ui/proposal.md
+++ b/openspec/changes/responsive-mobile-correction-ui/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+On a phone the correction workspace is not merely cramped — parts of it cannot be operated at all. The top bar is a single non-wrapping row of a menu button, the wordmark, three nav tabs and five icon actions, which overflows below roughly 640px; because `globals.css` sets `overflow-x: hidden` on `html, body`, the overflow is clipped rather than scrollable, so 設定 and ログアウト become physically unreachable. Selecting a suggestion — the one action the whole review step is made of — is bound to `onDoubleClick` plus a `group-hover`-revealed icon, and a touch screen has neither: a double-tap is a zoom gesture and there is no hover to reveal anything. The shell is sized with `100vh`, which on iOS Safari means the largest viewport, so the bottom of the app sits behind the browser toolbar, and the on-screen keyboard covers the very textarea being typed into.
+
+Underneath those is a structural problem. Below `lg` the editor and the review pane stack inside a `min-h-0 overflow-hidden` container while both declare `overflow-y-auto`, so the fixed viewport height is split between two competing scroll areas: the user gets a squeezed editor above a squeezed suggestion list, and after tapping 生成 the results are thousands of pixels away from the text they describe.
+
+## What Changes
+
+- **The shell tracks the real viewport.** Height comes from `dvh` (with a `vh` fallback, because a shell with no height collapses rather than degrades), and the layout viewport is made to follow the on-screen keyboard so the focused field stays visible while typing.
+- **The top bar stops clipping.** Below `md` the nav tabs move into the session drawer, which is where the session list already lives; the remaining controls fit one row at 320px. Pinch-zoom is left enabled.
+- **One pane at a time below `lg`.** A 編集 / 添削案 switch under the header shows either the text cards or the review column, each getting the full available height and a single scroll. Above `lg` the side-by-side layout with its resizable right pane is unchanged. The existing "jump to the suggestions card when reviewing a job" behavior switches the pane on mobile, where scrolling to a hidden element does nothing.
+- **Touch gets first-class affordances.** Actions previously revealed on hover stay visible where the pointer cannot hover, a single tap selects a suggestion, and tap targets reach 44px on coarse pointers. Desktop density and hover behavior are unchanged, because the switch is on pointer capability rather than screen width.
+- **Long rows wrap instead of colliding**: the session header and its timer badges, the suggestion card header, and the generate button's hit area.
+
+Not included: any change to what the AI is asked or what it returns, to persistence, or to the desktop layout. No new dependency.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `correction-workspace-ui`: adds requirements for viewport-accurate sizing, a non-clipping adaptive top bar, one-pane-at-a-time workspace presentation below `lg`, and pointer-capability-based touch affordances (including a single-tap route to selecting a proposal, which today is double-click only).
+
+## Impact
+
+- `frontend/src/app/page.tsx` — shell height, top bar, the mobile pane switch, session header wrapping, suggestion card affordances.
+- `frontend/src/app/layout.tsx` — `viewport` export (keyboard behavior), document language.
+- `frontend/src/app/globals.css` — viewport-height utilities.
+- `frontend/tailwind.config.js` — pointer-capability variants.
+- `frontend/src/components/ui/sheet.tsx`, `job-queue-carousel.tsx` — drawer sizing at 320px, carousel tap targets.
+- `frontend/jest.config.js` / test setup — a viewport + `matchMedia` harness, which does not exist today (58 of 66 source files have no responsive styling and there are no layout tests).
+
+No backend, API, schema, or environment change. Nothing to migrate or redeploy beyond the normal frontend build.

--- a/openspec/changes/responsive-mobile-correction-ui/specs/correction-workspace-ui/spec.md
+++ b/openspec/changes/responsive-mobile-correction-ui/specs/correction-workspace-ui/spec.md
@@ -1,0 +1,153 @@
+## ADDED Requirements
+
+### Requirement: Workspace Fits the Visible Viewport
+The workspace shell SHALL be sized to the viewport that is actually visible, not to the largest viewport the browser could present, so that no part of the application is left behind browser chrome or an on-screen keyboard. While a text field has focus, that field SHALL remain visible.
+
+#### Scenario: Mobile browser chrome is showing
+- **WHEN** the workspace is opened in a mobile browser whose address bar and toolbar occupy part of the screen
+- **THEN** the shell's height matches the space left between them
+- **AND** every control at the bottom of the shell is reachable without the page being taller than the visible area
+
+#### Scenario: On-screen keyboard opens over a text field
+- **GIVEN** the workspace is open on a touch device
+- **WHEN** the user focuses the 添削対象 text field and the on-screen keyboard appears
+- **THEN** the workspace is laid out within the space the keyboard leaves
+- **AND** the focused field remains visible rather than being covered by the keyboard
+
+#### Scenario: Browser does not support dynamic viewport units
+- **GIVEN** a browser that does not understand dynamic viewport units
+- **WHEN** the workspace renders
+- **THEN** the shell still receives a full-viewport height from a static fallback
+- **AND** the panes are laid out normally rather than collapsing to zero height
+
+### Requirement: Top Bar Remains Fully Operable on Narrow Viewports
+Every top-bar control SHALL remain reachable at viewport widths down to 320px. Because horizontal document overflow is clipped rather than scrollable, a control that does not fit MUST be relocated to a reachable place rather than allowed to overflow.
+
+#### Scenario: Narrow viewport keeps every action reachable
+- **GIVEN** a viewport 320px wide
+- **WHEN** the workspace renders
+- **THEN** the session-list trigger, the new-session action, notifications, settings and sign-out are all present and operable
+- **AND** no top-bar control is positioned outside the visible width
+
+#### Scenario: Section navigation moves into the session drawer
+- **GIVEN** a viewport below the `md` breakpoint, where the section tabs would not fit the top bar
+- **WHEN** the user opens the session drawer
+- **THEN** the drawer offers the same section choices the top bar shows on wider viewports
+- **AND** choosing one switches sections and closes the drawer
+
+#### Scenario: Wide viewport is unchanged
+- **GIVEN** a viewport at or above the `md` breakpoint
+- **WHEN** the workspace renders
+- **THEN** the section tabs appear in the top bar as before
+- **AND** they are not duplicated inside the drawer
+
+### Requirement: One Workspace Pane at a Time Below Large Viewports
+Below the `lg` breakpoint the system SHALL present the editing pane and the review pane one at a time, each occupying the full height available to the workspace, rather than dividing that height between them. At or above `lg` both panes SHALL remain visible side by side.
+
+#### Scenario: Narrow viewport shows the editor by default
+- **GIVEN** a viewport below the `lg` breakpoint with an active session
+- **WHEN** the workspace renders
+- **THEN** the 原文 / 模範回答訳文 / 添削対象 cards are shown
+- **AND** the review pane's job queue, suggestions and history are not shown
+- **AND** a control is offered for switching to the review pane
+
+#### Scenario: User switches to the review pane
+- **GIVEN** a viewport below the `lg` breakpoint showing the editing pane
+- **WHEN** the user activates the review switch
+- **THEN** the review pane is shown using the full workspace height with a single scroll region
+- **AND** the editing pane is not shown
+
+#### Scenario: Pending review work is discoverable from the editing pane
+- **GIVEN** a viewport below the `lg` breakpoint showing the editing pane
+- **WHEN** the active session has suggestions awaiting review, or a generation job is queued or running
+- **THEN** the review switch indicates that there is something to review without the user leaving the editing pane
+
+#### Scenario: Reviewing a job brings the review pane forward
+- **GIVEN** a viewport below the `lg` breakpoint showing the editing pane
+- **WHEN** the user opens a completed job for review from the job queue or the notification list
+- **THEN** the review pane is brought forward so the suggestions are visible
+- **AND** the user does not have to find the switch themselves
+
+#### Scenario: Large viewport keeps both panes
+- **GIVEN** a viewport at or above the `lg` breakpoint
+- **WHEN** the workspace renders
+- **THEN** the editing pane and the review pane are both visible side by side
+- **AND** the review pane keeps its user-adjustable width
+- **AND** no pane switch is offered
+
+### Requirement: Touch Affordances Follow Pointer Capability
+Controls SHALL be operable with a coarse pointer. An action MUST NOT depend on hovering to become visible, or on a double activation to take effect, when the pointer cannot hover. Whether these accommodations apply SHALL be decided by the pointer's capability, not by viewport width, so that a small window on a mouse-driven machine keeps its hover behavior and a large touch screen still gets touch affordances.
+
+#### Scenario: Card actions are visible without hover
+- **GIVEN** a device whose pointer cannot hover
+- **WHEN** a suggestion card or a session list entry renders
+- **THEN** its actions are visible without any pointer interaction
+
+#### Scenario: A single tap selects a proposal
+- **GIVEN** a device whose pointer cannot hover
+- **WHEN** the user taps a proposal's selection control once
+- **THEN** the proposal's selection state changes
+- **AND** no double activation is required
+
+#### Scenario: Tap targets are large enough for a finger
+- **GIVEN** a device whose pointer cannot hover
+- **WHEN** any icon-only control renders
+- **THEN** its activation area is at least 44px in each dimension
+
+#### Scenario: Hover-capable pointers keep the existing behavior
+- **GIVEN** a device with a hover-capable, fine pointer
+- **WHEN** a suggestion card renders
+- **THEN** its actions stay hidden until the card is hovered, as before
+- **AND** the control sizes are unchanged
+
+### Requirement: Page Zoom Remains Available
+The system SHALL NOT suppress the user's ability to zoom the page.
+
+#### Scenario: Pinch zoom on a touch device
+- **GIVEN** the workspace is open on a touch device
+- **WHEN** the user pinches to zoom
+- **THEN** the page scales
+- **AND** neither a maximum scale nor a scalability restriction prevents it
+
+## MODIFIED Requirements
+
+### Requirement: Proposal Selection and Ordering
+The system SHALL let the user select or deselect each proposal through a control that is operable with a single activation and without hovering, and SHALL track and display the order in which proposals were selected.
+
+#### Scenario: User selects a proposal
+- GIVEN a proposal is currently unselected
+- WHEN the user activates its selection control
+- THEN the proposal becomes selected and is assigned the next sequential selection-order number
+- AND the selection counter increments by 1
+- AND a small badge showing its selection-order number appears next to the selection control
+
+#### Scenario: User deselects a proposal
+- GIVEN a selected proposal with a selection-order number
+- WHEN the user activates its selection control
+- THEN the proposal becomes unselected and loses its selection-order number
+- AND every other selected proposal whose order number was greater than the deselected one has its order number decremented by 1
+- AND the selection counter decrements by 1
+
+#### Scenario: Editing a proposal's comment does not change its selection
+- GIVEN a selected proposal whose comment is being edited
+- WHEN the user interacts with the comment field
+- THEN the proposal's selection state is unaffected
+
+### Requirement: Responsive Sidebar Navigation
+The system SHALL present the session sidebar as a slide-out sheet on small (mobile/`lg`-breakpoint-below) viewports and as a collapsible fixed sidebar on large viewports. On viewports too narrow for the top bar to carry the section tabs, the sheet SHALL also carry them.
+
+#### Scenario: Mobile viewport shows a sheet-based sidebar
+- GIVEN the viewport is below the `lg` breakpoint
+- WHEN the user taps the floating menu button
+- THEN a slide-out sheet opens from the left showing the session list and "新しいセッション" action
+
+#### Scenario: Desktop viewport shows a collapsible fixed sidebar
+- GIVEN the viewport is at or above the `lg` breakpoint
+- WHEN the user clicks the sidebar's collapse/expand toggle
+- THEN the fixed left sidebar collapses to an icon-only rail or expands to show full session details, without affecting the main content's session state
+
+#### Scenario: Sheet fits a narrow viewport
+- GIVEN a viewport 320px wide
+- WHEN the sheet opens
+- THEN the sheet and its contents fit within the viewport width
+- AND the session list scrolls within the sheet's own height rather than being cut off by browser chrome

--- a/openspec/changes/responsive-mobile-correction-ui/tasks.md
+++ b/openspec/changes/responsive-mobile-correction-ui/tasks.md
@@ -1,0 +1,60 @@
+## 1. Viewport sizing
+
+- [ ] 1.1 Add `h-viewport` / `min-h-viewport` utilities to `globals.css` with the `vh` → `dvh` declaration pair, and a comment saying why the fallback is load-bearing
+- [ ] 1.2 Replace `h-screen` on the shell and `min-h-screen` on the auth-loading screen with them
+- [ ] 1.3 Add the `viewport` export to `layout.tsx` with `interactiveWidget: 'resizes-content'`, and without `maximumScale` / `userScalable`
+- [ ] 1.4 Set the document language to Japanese so CJK line-breaking and font selection are correct
+- [ ] 1.5 Replace the two `calc(100vh - …)` guesses (drawer session list, empty-session state) with flex-derived heights
+
+## 2. Pointer-capability variants
+
+- [ ] 2.1 Add `can-hover` and `touch` variants to `tailwind.config.js` via `addVariant`
+- [ ] 2.2 Convert every `opacity-0 group-hover:opacity-100` reveal (suggestion card actions, session list delete, toast close) to the `can-hover` form so the action is visible where the pointer cannot hover
+- [ ] 2.3 Give every icon-only control a `touch:`-scoped 44px minimum: card copy/select, session delete, header cluster, carousel chevrons, history actions
+- [ ] 2.4 Confirm the desktop rendering is unchanged — the variants must add rules under a media query, never alter the base class
+
+## 3. Top bar
+
+- [ ] 3.1 Hide the section tabs below `md` and render the same choices inside the session drawer, closing the drawer on selection
+- [ ] 3.2 Verify the remaining controls fit 320px, and that the icon cluster cannot be pushed outside the clipped width
+- [ ] 3.3 Let the session header and its LATEST / AVG / Saved badges wrap instead of colliding with the session name
+
+## 4. One pane at a time below `lg`
+
+- [ ] 4.1 Add `mobilePane` state, in memory only
+- [ ] 4.2 Add the segmented 編集 / 添削案 switch, rendered only below `lg`, with tap targets sized for a finger
+- [ ] 4.3 Show exactly one pane below `lg` by conditional visibility classes, without moving any JSX
+- [ ] 4.4 Give the review pane `flex-1` below `lg` so the single visible pane owns the full height and one scroll region
+- [ ] 4.5 Surface pending review work on the switch: suggestion count, and queued/running generations
+- [ ] 4.6 Have the existing scroll-to-suggestions effect also bring the review pane forward, so job-queue and notification review both work below `lg`
+- [ ] 4.7 Make the generate button a comfortable full-width target on narrow viewports
+
+## 5. Narrow-viewport sizing of the rest
+
+- [ ] 5.1 Make the session drawer fit 320px (it is fixed at `w-80` today) and scroll within its own height
+- [ ] 5.2 Check the notification dropdown, prompt-settings dialog and job-queue cards at 320px for clipped or overflowing content
+
+## 6. Tests
+
+- [ ] 6.1 Add a `matchMedia` stub and a viewport-width helper to the jest setup, wired through `jest.config.js`
+- [ ] 6.2 Below `lg`: the editor pane renders and the review pane does not, and the switch reverses that
+- [ ] 6.3 Reviewing a job from the queue brings the review pane forward
+- [ ] 6.4 The switch reports pending suggestions and running generations
+- [ ] 6.5 At `lg` and above: both panes render and no switch is offered
+- [ ] 6.6 A single activation of a proposal's selection control selects it, and again deselects it, with the order bookkeeping from the spec
+- [ ] 6.7 Section tabs are reachable from the drawer, and are not duplicated when the top bar carries them
+- [ ] 6.8 The viewport export enables keyboard-aware layout and does not disable zoom
+- [ ] 6.9 Run frontend jest, `tsc`, and lint
+
+## 7. Manual verification (real layout, which jsdom cannot answer)
+
+- [ ] 7.1 At 320px, 375px and 768px: every top-bar control reachable, no horizontal clipping
+- [ ] 7.2 Focus the 添削対象 field with an on-screen keyboard open and confirm the field stays visible
+- [ ] 7.3 Walk one correction end to end on a phone-sized viewport: enter text, generate, switch to 添削案, select three suggestions by single tap, confirm and copy
+- [ ] 7.4 Confirm the desktop layout at 1440px is visually unchanged from `main`
+
+## 8. Docs
+
+- [ ] 8.1 `docs/UI-DESIGN.md`: the two breakpoints in use and what each decides, the pointer-capability variants, and the 44px rule
+- [ ] 8.2 `docs/SYSTEM-DESIGN.md`: the mobile pane switch as workspace presentation, and that it carries no persisted state
+- [ ] 8.3 Correct the stale `next.config.js` description in `AGENTS.md` if it is still claiming no explicit output mode

--- a/openspec/changes/responsive-mobile-correction-ui/tasks.md
+++ b/openspec/changes/responsive-mobile-correction-ui/tasks.md
@@ -1,60 +1,60 @@
 ## 1. Viewport sizing
 
-- [ ] 1.1 Add `h-viewport` / `min-h-viewport` utilities to `globals.css` with the `vh` → `dvh` declaration pair, and a comment saying why the fallback is load-bearing
-- [ ] 1.2 Replace `h-screen` on the shell and `min-h-screen` on the auth-loading screen with them
-- [ ] 1.3 Add the `viewport` export to `layout.tsx` with `interactiveWidget: 'resizes-content'`, and without `maximumScale` / `userScalable`
-- [ ] 1.4 Set the document language to Japanese so CJK line-breaking and font selection are correct
-- [ ] 1.5 Replace the two `calc(100vh - …)` guesses (drawer session list, empty-session state) with flex-derived heights
+- [x] 1.1 Add `h-viewport` / `min-h-viewport` utilities to `globals.css` with the `vh` → `dvh` declaration pair, and a comment saying why the fallback is load-bearing
+- [x] 1.2 Replace `h-screen` on the shell and `min-h-screen` on the auth-loading screen with them
+- [x] 1.3 Add the `viewport` export to `layout.tsx` with `interactiveWidget: 'resizes-content'`, and without `maximumScale` / `userScalable`
+- [x] 1.4 Set the document language to Japanese so CJK line-breaking and font selection are correct
+- [x] 1.5 Replace the two `calc(100vh - …)` guesses (drawer session list, empty-session state) with flex-derived heights — three in the end; the prompt dialog's `45vh`/`55vh` textarea was the same mistake in another unit
 
 ## 2. Pointer-capability variants
 
-- [ ] 2.1 Add `can-hover` and `touch` variants to `tailwind.config.js` via `addVariant`
-- [ ] 2.2 Convert every `opacity-0 group-hover:opacity-100` reveal (suggestion card actions, session list delete, toast close) to the `can-hover` form so the action is visible where the pointer cannot hover
-- [ ] 2.3 Give every icon-only control a `touch:`-scoped 44px minimum: card copy/select, session delete, header cluster, carousel chevrons, history actions
-- [ ] 2.4 Confirm the desktop rendering is unchanged — the variants must add rules under a media query, never alter the base class
+- [x] 2.1 Add a `can-hover` variant to `tailwind.config.js` via `addVariant`. No `touch` variant: 2.3 needs a whole rule under `hover: none`, not a variant of one utility, so it is a class in `globals.css` instead
+- [x] 2.2 Convert every `opacity-0 group-hover:opacity-100` reveal (suggestion card actions, session list delete, toast close) to the `can-hover` form so the action is visible where the pointer cannot hover
+- [x] 2.3 Give every icon-only control a 44px minimum under `hover: none`: card copy/select, session delete, header cluster, carousel chevrons, history actions, dialog and sheet dismiss
+- [x] 2.4 Confirm the desktop rendering is unchanged — verified in the generated stylesheet (the rules sit inside `@media (hover: hover) and (pointer: fine)` / `@media (hover: none)`, never on the base class) and in the browser at 1280px
 
 ## 3. Top bar
 
-- [ ] 3.1 Hide the section tabs below `md` and render the same choices inside the session drawer, closing the drawer on selection
-- [ ] 3.2 Verify the remaining controls fit 320px, and that the icon cluster cannot be pushed outside the clipped width
-- [ ] 3.3 Let the session header and its LATEST / AVG / Saved badges wrap instead of colliding with the session name
+- [x] 3.1 Hide the section tabs below `md` and render the same choices inside the session drawer, closing the drawer on selection
+- [x] 3.2 Verify the remaining controls fit 320px — they did not with the tabs alone removed, so identity and sign-out move to the drawer below `sm` as well (design.md Decision 5)
+- [x] 3.3 Let the session header and its LATEST / AVG / Saved badges wrap instead of colliding with the session name
 
 ## 4. One pane at a time below `lg`
 
-- [ ] 4.1 Add `mobilePane` state, in memory only
-- [ ] 4.2 Add the segmented 編集 / 添削案 switch, rendered only below `lg`, with tap targets sized for a finger
-- [ ] 4.3 Show exactly one pane below `lg` by conditional visibility classes, without moving any JSX
-- [ ] 4.4 Give the review pane `flex-1` below `lg` so the single visible pane owns the full height and one scroll region
-- [ ] 4.5 Surface pending review work on the switch: suggestion count, and queued/running generations
-- [ ] 4.6 Have the existing scroll-to-suggestions effect also bring the review pane forward, so job-queue and notification review both work below `lg`
-- [ ] 4.7 Make the generate button a comfortable full-width target on narrow viewports
+- [x] 4.1 Add `mobilePane` state, in memory only
+- [x] 4.2 Add the segmented 編集 / 添削案 switch, rendered only below `lg`, with tap targets sized for a finger
+- [x] 4.3 Show exactly one pane below `lg` by conditional visibility classes, without moving any JSX
+- [x] 4.4 Give the review pane `flex-1` below `lg` so the single visible pane owns the full height and one scroll region
+- [x] 4.5 Surface pending review work on the switch: suggestion count, falling back to queued/running generations when there is nothing to review yet
+- [x] 4.6 Have the existing scroll-to-suggestions effect also bring the review pane forward, so job-queue and notification review both work below `lg`
+- [x] 4.7 Make the generate button a comfortable full-width target on narrow viewports
 
 ## 5. Narrow-viewport sizing of the rest
 
-- [ ] 5.1 Make the session drawer fit 320px (it is fixed at `w-80` today) and scroll within its own height
-- [ ] 5.2 Check the notification dropdown, prompt-settings dialog and job-queue cards at 320px for clipped or overflowing content
+- [x] 5.1 Make the session drawer fit 320px (it was fixed at `w-80`) and scroll within its own height
+- [x] 5.2 Check the notification dropdown, prompt-settings dialog and job-queue cards at 320px. The dropdown was already capped at `calc(100vw-2rem)` and the carousel derives card widths from the measured track, so both were fine; the dialog needed the height work in 1.5 and was then confirmed in the browser
 
 ## 6. Tests
 
-- [ ] 6.1 Add a `matchMedia` stub and a viewport-width helper to the jest setup, wired through `jest.config.js`
-- [ ] 6.2 Below `lg`: the editor pane renders and the review pane does not, and the switch reverses that
-- [ ] 6.3 Reviewing a job from the queue brings the review pane forward
-- [ ] 6.4 The switch reports pending suggestions and running generations
-- [ ] 6.5 At `lg` and above: both panes render and no switch is offered
-- [ ] 6.6 A single activation of a proposal's selection control selects it, and again deselects it, with the order bookkeeping from the spec
-- [ ] 6.7 Section tabs are reachable from the drawer, and are not duplicated when the top bar carries them
-- [ ] 6.8 The viewport export enables keyboard-aware layout and does not disable zoom
-- [ ] 6.9 Run frontend jest, `tsc`, and lint
+- [x] 6.1 No `matchMedia` stub or viewport helper was needed — the pane switch reads no viewport width (design.md Decision 9). One test does narrow `window.innerWidth`, but only because the *pre-existing* docked-pane logic reads it
+- [x] 6.2 The switch reports the editor as showing on a fresh session, and reverses on activation. Which pane is *painted* is CSS, so it is checked in 7.1 rather than asserted here
+- [x] 6.3 Reviewing a job from the queue brings the review pane forward
+- [x] 6.4 The switch reports pending suggestions and running generations
+- [x] 6.5 Dropped as untestable in jsdom: "no switch at lg" is a media query, and asserting the class string would restate the implementation without being able to fail when CSS does not resolve as the names imply. Covered by 7.4
+- [x] 6.6 A single activation of a proposal's selection control selects it, and again deselects it, with the order bookkeeping from the spec
+- [x] 6.7 Section tabs are reachable from the drawer and switch section, closing the drawer. Note both copies are always in the DOM — `hidden` decides which is exposed — so the test addresses the drawer's copy through the drawer
+- [x] 6.8 The viewport export enables keyboard-aware layout and does not disable zoom
+- [x] 6.9 Run frontend jest, `tsc`, and lint — 25 suites / 285 tests pass; lint clean apart from a pre-existing custom-font warning
 
 ## 7. Manual verification (real layout, which jsdom cannot answer)
 
-- [ ] 7.1 At 320px, 375px and 768px: every top-bar control reachable, no horizontal clipping
-- [ ] 7.2 Focus the 添削対象 field with an on-screen keyboard open and confirm the field stays visible
-- [ ] 7.3 Walk one correction end to end on a phone-sized viewport: enter text, generate, switch to 添削案, select three suggestions by single tap, confirm and copy
-- [ ] 7.4 Confirm the desktop layout at 1440px is visually unchanged from `main`
+- [x] 7.1 At 320px, 390px and 768px: every top-bar control reachable, no horizontal clipping, no horizontal page scroll. Also checked the drawer (tabs, search, session list and the account row all visible without clipping) and the prompt dialog (all three footer buttons reachable at 390px without scrolling)
+- [ ] 7.2 Focus the 添削対象 field with an on-screen keyboard open and confirm the field stays visible — **not verifiable here**: the verification browser is desktop Chrome with no on-screen keyboard, and DevTools device emulation does not raise one. `interactiveWidget` is asserted in 6.8; its effect needs a real touch device
+- [~] 7.3 Walk one correction end to end on a phone-sized viewport — done as far as this environment allows (create session, enter both texts, switch panes both ways, open and dismiss the settings dialog). Generation itself was not run: no AI provider keys exist in this environment
+- [x] 7.4 Confirm the desktop layout at 1280px is unchanged from `main`: tabs, avatar and sign-out in the bar, both panes side by side with the resize handle, and no pane switch
 
 ## 8. Docs
 
-- [ ] 8.1 `docs/UI-DESIGN.md`: the two breakpoints in use and what each decides, the pointer-capability variants, and the 44px rule
-- [ ] 8.2 `docs/SYSTEM-DESIGN.md`: the mobile pane switch as workspace presentation, and that it carries no persisted state
-- [ ] 8.3 Correct the stale `next.config.js` description in `AGENTS.md` if it is still claiming no explicit output mode
+- [x] 8.1 `docs/UI-DESIGN.md`: the breakpoints in use and what each decides, the pointer-capability variants, and the 44px rule
+- [x] 8.2 `docs/SYSTEM-DESIGN.md`: the mobile pane switch as workspace presentation, and that it carries no persisted state
+- [x] 8.3 Correct the stale `next.config.js` description in `AGENTS.md` — it was still claiming the explicit output mode had been removed


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

ワークスペースは lg 以上の 3 カラム前提で組まれており、スマートフォンからは実用にならない状態だった。

- シェルの高さが `100vh`。モバイルではこれは「最大のビューポート」を指すため、下端がブラウザのツールバーに隠れる。キーボードを開くと入力中の欄がキーボードの裏に回ることもある
- トップバーが折り返さない 1 行に 9 個の要素を並べており、必要幅は約 500px。320px では右端（設定・ログアウト）が画面外へ出る
- lg 未満では編集ペーンと添削ペーンが縦積みになり、固定高のコンテナの中で 2 つの独立スクロール領域が高さを取り合う。提案が増えると編集側がほぼ潰れる
- 提案の選択・コピー・セッション削除などが `group-hover` で出現する作りで、hover 状態を持たないタッチ端末では見えない。提案の選択はダブルクリックのみ
- アイコンのみのボタンが 26px 程度で、指のターゲットとして小さい

## 変更点

コミットごとに 1 つの問題に対応している。

| コミット | 内容 |
|---|---|
| `64afadf` | 高さを `dvh`（`vh` フォールバック付き）に。`interactiveWidget: resizes-content` でキーボードに追従。`calc(100vh - …)` 3 箇所を flex 由来の高さへ |
| `818f434` | 表示条件を「hover できるポインタか」(`can-hover:`) に。タッチでは常時表示、単一タップでの選択、44px の最小ターゲット |
| `5afa8f2` | md 未満はセクションタブを、sm 未満はアカウント操作をドロワーへ移動。320px に収まる |
| `c46c287` | lg 未満は編集／添削案のどちらか一方を全高で表示し、上部にスイッチを置く。ジョブ確定時に添削案ペーンを前に出す |
| `c30dd24` | 320px で溢れる 4 行を折り返し。ダイアログ／シートの閉じるボタンもタッチターゲット化 |
| `e151cfb` | セッション名が短いバッジ 2 個に幅を譲って切り詰められていたのを修正 |
| `e10ae69` | 狭い画面で生成ボタンを全幅に |
| `9919178` | 単一タップ選択・ドロワーのタブ・viewport 宣言のテスト |
| `f2be502` | ドキュメント更新 |

ブレークポイントの判定は CSS に一任している（`lg:` クラスで表示を切り替える）ため、JS 側に「lg とは何か」の二重定義を作っていない。ペーンの選択は永続化していない（離れたセッションのレビュー側で開き直してしまうため、セッション切替えでリセット）。ピンチズームは意図的に有効なまま残している（密度の高い CJK テキストを拡大する必要があるため）。

## テスト

- 追加: `mobilePaneSwitch.test.tsx`（5 件）、`viewportConfig.test.ts`（2 件）。jsdom はスタイルシートを適用しないため、CSS ではない部分だけを検証している（スイッチの状態、レビュー到着時の遷移、単一タップ選択と選択順、ドロワーからのセクション切替え、viewport 宣言）
- `npx tsc --noEmit` / `npx jest`（25 suites, 285 tests）/ `npx next lint` / `next build` すべてパス
- ローカル Postgres + バックエンドを立ててブラウザで 320 / 390 / 768 / 1280px を目視確認。トップバーのクリップなし、横スクロールなし、lg 未満は片方のペーンのみ、lg 以上は従来どおり 2 ペーン並列＋リサイズハンドル、設定ダイアログの 3 ボタンは 390px でスクロールなしで到達可能

## 未検証（環境の制約）

- オンスクリーンキーボードを開いた状態での入力欄の可視性。検証ブラウザはデスクトップ Chrome で、DevTools のデバイスエミュレーションはキーボードを出さない。`interactiveWidget` の設定自体はテストで担保している
- 生成を含む一連の添削フロー。この環境に AI プロバイダの鍵がないため生成は実行していない（ペーン切替え・入力・ダイアログまでは実施）

## 付随して見つかった既存の不整合

`AGENTS.md` は `frontend/next.config.js` が明示的な `output` モードを外したと書いていたが、`output: 'export'` は現存する。`f2be502` で修正した。併せて `frontend/out/` に `.gitignore` 追加前の追跡ファイルが 18 件残っており、ローカルビルドで差分が出る点も注記した（本 PR には含めていない）。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00950-1145-781d-81cb-dc51a6ac08dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00950-1145-781d-81cb-dc51a6ac08dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

