### PR TITLE
test: 開発機の実APIキーがテスト結果を変えてしまう問題を直す

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from pathlib import Path
 
@@ -9,20 +10,58 @@ if str(BACKEND_DIR) not in sys.path:
     sys.path.insert(0, str(BACKEND_DIR))
 
 
-@pytest.fixture(autouse=True)
-def _isolate_provider_state():
-    """
-    Clear credential cooldowns and buffered health observations between tests.
+PROVIDER_ENV_VARS = (
+    "GEMINI_API_KEY",
+    "GEMINI_API_KEYS",
+    "GEMINI_MODEL",
+    "GEMINI_THINKING_LEVEL",
+    "GROQ_API_KEY",
+    "GROQ_API_KEYS",
+    "GROQ_MODEL",
+    "CLOUDFLARE_ACCOUNT_ID",
+    "CLOUDFLARE_ACCOUNT_IDS",
+    "CLOUDFLARE_API_TOKEN",
+    "CLOUDFLARE_API_TOKENS",
+)
 
-    These are process-global by design — the failover chain now skips a provider
-    whose whole pool is cooled down — so a cooldown left behind by one test would
-    silently change which provider another test's chain calls.
+
+@pytest.fixture(autouse=True)
+def _isolate_provider_state(request):
+    """
+    Clear credential cooldowns, buffered health observations, and provider
+    credentials between tests.
+
+    The cooldowns are process-global by design — the failover chain now skips a
+    provider whose whole pool is cooled down — so a cooldown left behind by one
+    test would silently change which provider another test's chain calls.
+
+    The credentials are cleared for the same reason: which providers are
+    configured decides which ones a pass plans to call. `backend/app/main.py`
+    loads `conf/.env` on import, so a developer with real keys ran a different
+    chain than CI did, and a test could pass on one and fail on the other.
+    Tests set the credentials they need. The exception is the `integration`
+    marker: those tests are opt-in live smokes whose whole point is to spend a
+    real key, and their skip conditions are evaluated at collection time, before
+    this fixture could put anything back.
     """
     from app.llm.key_pool import reset_key_pool_state
     from app.llm.provider_health import reset_provider_health_state
 
+    keep_credentials = request.node.get_closest_marker("integration") is not None
+    saved = (
+        {}
+        if keep_credentials
+        else {name: os.environ.pop(name, None) for name in PROVIDER_ENV_VARS}
+    )
     reset_key_pool_state()
     reset_provider_health_state()
-    yield
-    reset_key_pool_state()
-    reset_provider_health_state()
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        reset_key_pool_state()
+        reset_provider_health_state()

--- a/backend/tests/test_provider_env_isolation.py
+++ b/backend/tests/test_provider_env_isolation.py
@@ -1,0 +1,22 @@
+"""The test environment must not inherit real provider credentials.
+
+`backend/app/main.py` loads `conf/.env` on import, so before the autouse
+fixture in `conftest.py` scrubbed them, a developer with keys on disk ran a
+different failover chain than CI did: `_plan_providers()` saw a configured
+Cloudflare it was never told about, so a test asserting "every provider is
+cooled down, so release the soonest one" found a healthy third provider and the
+release never happened. It failed locally and passed in CI.
+"""
+
+import os
+
+from tests.conftest import PROVIDER_ENV_VARS
+
+
+def test_no_provider_credentials_leak_into_a_test():
+    leaked = [name for name in PROVIDER_ENV_VARS if os.environ.get(name)]
+    assert leaked == [], (
+        "provider credentials visible to a test: "
+        f"{leaked}. Tests must set the credentials they need, so the "
+        "configured-provider set does not depend on the developer's conf/.env."
+    )


### PR DESCRIPTION
## うまくいかなかったこと

PR #4（`route-around-exhausted-providers`）で追加された `TestChainPlan::test_everything_cooled_still_leaves_one_provider_to_call` が、**キーを持っている開発機でだけ失敗**します。CI は緑のままなので、マージ時には見えませんでした。

```
FAILED tests/test_provider_health.py::TestChainPlan::test_everything_cooled_still_leaves_one_provider_to_call
assert False is True
 where False = _ProviderPlan(configured=True, unavailable_reason='Groq skipped: every credential was already in cooldown from an earlier request, expected usable in 20s').usable
```

原因は環境変数の混入です。`backend/app/main.py` は import 時に `conf/.env` を読むため、Cloudflare の鍵をローカルに持っている人のプロセスでは CF が「設定済み」になります。このテストは Gemini と Groq を全てクールダウンさせたうえで「全滅なら最も早く復帰する 1 つは必ず試す」を検証するものですが、テストが知らない健全な 3 つ目のプロバイダが居るため「全滅」にならず、解放が起きません。CI には鍵が無いので通ります。

同じクラス内の隣のテストは `CLOUDFLARE_ACCOUNT_ID(S)` を `delenv` しており、このテストだけ漏れていました。

## 直し方

個別に `delenv` を足すのではなく、PR #4 が同じ理由で追加した autouse fixture（クールダウンのリセット）に**認証情報のスクラブ**を足しました。どのプロバイダが設定されているかは、クールダウンと同じく「そのパスがどれを呼ぶか」を直接左右するプロセス全体の状態なので、片方だけ隔離しても意味がありません。テストは必要な鍵を自分で `setenv` します。

`integration` マーカーの付いた live smoke は対象外です。実鍵を使うことが目的であり、かつ skip 条件は collection 時に評価されるため、fixture が戻す前に判定が終わってしまいます。

`tests/test_provider_env_isolation.py` に、非 integration テストに認証情報が見えていないことを直接確認する回帰テストを追加しました。

## 検証

| 条件 | 修正前 | 修正後 |
|---|---|---|
| 実 `conf/.env` あり（開発機） | 1 failed, 420 passed, 1 skipped | **422 passed, 1 skipped** |
| 鍵なし（CI 相当） | 421 passed, 1 skipped | **422 passed, 1 skipped** |
| `CLOUDFLARE_ACCOUNT_ID` / `GROQ_API_KEYS` / `GEMINI_MODEL` を明示注入 | 1 failed | **422 passed** |

`ruff check` クリーン。フロントエンドは無関係ですが、main の作業ツリーとは別の worktree で `npx tsc --noEmit` と `npx jest`（25 suites / 285 tests）が通ることも確認済みです。

Failover 順（Gemini → Groq → Cloudflare）とプロダクションコードには一切触れていません。テストの隔離だけの変更です。